### PR TITLE
Синтетическая челка: высота по меню-бару и не занятая середина бара

### DIFF
--- a/Sources/Cyclop/Notch/NotchController.swift
+++ b/Sources/Cyclop/Notch/NotchController.swift
@@ -172,6 +172,12 @@ final class NotchController {
         pointer.openRect = geometry.hoverRect
         pointer.warmZone = geometry.warmZone
         pointer.closeRect = geometry.expandedHoverRect
+        // A real notch is a hole: nothing is under it, so opening the moment the
+        // pointer arrives costs nothing. A synthetic one sits on a working menu
+        // bar, and a pointer crossing the middle of it is usually on its way
+        // somewhere else — unfolding the panel over what it was reaching for is
+        // the whole complaint. Staying put is what asks for the panel.
+        pointer.openDelay = geometry.isPhysical ? 0.05 : 0.3
         pointer.isDragging = { [weak root] in root?.isReceivingDrag ?? false }
         pointer.isPanelOpen = { [weak vm] in vm?.isOpen ?? false }
         pointer.onChange = { [weak self] inside in
@@ -290,7 +296,10 @@ final class NotchController {
 
     private func applyActiveRect(open: Bool) {
         guard let vm = viewModel, let rootView else { return }
-        let size = open ? vm.geometry.expandedSize : vm.geometry.notchSize
+        // Collapsed, the panel claims only its target strip — on a synthetic
+        // notch that is deliberately shallower than the menu bar, so clicks on
+        // status items underneath reach them instead of a panel nobody can see.
+        let size = open ? vm.geometry.expandedSize : vm.geometry.collapsedSize
         var rect = vm.geometry.contentRect(for: size)
         if open {
             // Slack so the concave shoulders stay grabbable. Never while

--- a/Sources/Cyclop/Notch/NotchGeometry.swift
+++ b/Sources/Cyclop/Notch/NotchGeometry.swift
@@ -104,14 +104,29 @@ struct NotchGeometry {
         )
     }
 
+    /// Depth of the collapsed target, measured down from the top edge.
+    ///
+    /// A real notch is a hole: the whole of it can be claimed, because there is
+    /// nothing underneath to claim it from. A synthetic one is cut out of a
+    /// working menu bar — and the middle of the bar is where status items pile
+    /// up once there are a few (measured on a 13" M1: they start at x≈757 while
+    /// the synthetic notch spans 630…810). Claiming the full bar height there
+    /// puts the panel in front of icons the user is aiming at. A strip along the
+    /// very top edge is reached by throwing the pointer up — the same gesture as
+    /// ever — while a pointer travelling to an icon stays below it.
+    var collapsedDepth: CGFloat { isPhysical ? notchSize.height : 8 }
+
+    /// Size of the collapsed target: the notch itself, or the strip above.
+    var collapsedSize: CGSize { CGSize(width: notchSize.width, height: collapsedDepth) }
+
     /// Hover target while collapsed, in global screen coordinates. Slightly
     /// taller than the notch so the panel opens just before the pointer lands.
     var hoverRect: CGRect {
         includingTopEdge(CGRect(
             x: notchCenterX - notchSize.width / 2 - 6,
-            y: screen.frame.maxY - notchSize.height - 4,
+            y: screen.frame.maxY - collapsedDepth - (isPhysical ? 4 : 0),
             width: notchSize.width + 12,
-            height: notchSize.height + 4
+            height: collapsedDepth + (isPhysical ? 4 : 0)
         ))
     }
 

--- a/Sources/Cyclop/Notch/NotchGeometry.swift
+++ b/Sources/Cyclop/Notch/NotchGeometry.swift
@@ -33,9 +33,18 @@ struct NotchGeometry {
 
         // No notch: pretend there is one the size of a typical MacBook cutout so
         // the app still works on external displays and pre-2021 machines.
+        //
+        // The height has to be the menu bar's own, not `NSStatusBar.thickness`:
+        // the two disagree by several points (22 against 30 on a 13" M1 running
+        // macOS 26), and the shape is drawn filled black, so anything short of
+        // the bar's height reads as a tab stuck onto the menu bar rather than a
+        // cutout of it. `visibleFrame` is what the menu bar actually took —
+        // measured, not assumed. It collapses to zero when the bar auto-hides,
+        // which is what the floor is for.
+        let menuBarHeight = screen.frame.maxY - screen.visibleFrame.maxY
         return NotchGeometry(
             screen: screen,
-            notchSize: CGSize(width: 180, height: max(NSStatusBar.system.thickness, 24)),
+            notchSize: CGSize(width: 180, height: max(menuBarHeight, NSStatusBar.system.thickness, 24)),
             notchCenterX: screen.frame.midX,
             isPhysical: false
         )


### PR DESCRIPTION
Чинит первую и третью находки из #3.

**Первый коммит — высота.** `frame.maxY - visibleFrame.maxY` вместо
`NSStatusBar.system.thickness`: на 13" M1 под macOS 26 они расходятся на 6 pt
(22 против 30), и заливка силуэта не доходит до кромки бара. Прежние значения
оставлены полом — при автоскрытии меню-бара разница схлопывается в ноль.

**Второй — глубина цели в покое.** У синтетической челки она теперь своя:
полоса 8 pt по верхней кромке (`collapsedDepth`), по ней же считается
интерактивный прямоугольник. Курсор, идущий к иконке в баре, проходит ниже
полосы; чтобы позвать панель, его надо довести до кромки — тот же бросок
вверх, что и раньше. `openDelay` для синтетической челки поднят до 0.3 с.

У физической челки обе величины прежние: под вырезом ничего нет, и платить
задержкой там не за что. Обе правки под `isPhysical == false`.

**Чего делать нельзя:** совсем убрать интерактивность в покое. Именно она
делает окно приёмником перетаскивания — окно с `ignoresMouseEvents` не
рассматривается как цель drag&drop, и полка перестанет принимать файлы.
Поэтому прямоугольник сужен, а не убран.

**Проверено** на MacBookPro17,1 / macOS 26.5.1: курсор на статус-иконке (y=15)
панель не разворачивает, на кромке (y=1) — разворачивает; в покое меню-бар не
тронут. Курсор ставился скриптом; снимки «до/после» приложены к #3.

**Не проверено:** поведение на маке с челкой — такой машины у меня нет. По
построению оно не менялось, но глазами не видел.