### PR TITLE
Синхронизация медиа на macOS 26: коннекторы плееров, живая позиция, обложки Spotify

### DIFF
--- a/Sources/Cyclop/Services/MediaController.swift
+++ b/Sources/Cyclop/Services/MediaController.swift
@@ -24,6 +24,11 @@ final class MediaController: ObservableObject {
     @Published private(set) var duration: TimeInterval = 0
     @Published private(set) var position: TimeInterval = 0
     @Published private(set) var sourceName: String?
+    /// Nil for sessions without a connector (browser tabs) — the pane hides
+    /// the corresponding controls rather than show knobs wired to nothing.
+    @Published private(set) var volume: Int?
+    @Published private(set) var shuffle: Bool?
+    @Published private(set) var repeatMode: RepeatMode?
 
     private let feed = NowPlayingFeed()
     private var feedAvailable = true
@@ -79,6 +84,14 @@ final class MediaController: ObservableObject {
     private var queryCounter = 0
     private var appliedQuery = 0
     private var poller: Timer?
+    /// While the user drags the volume slider, polled readings lag the drag
+    /// and would snap the knob back — local intent wins for a beat.
+    private var volumeHold: Date?
+    /// Debounces the drag's stream of values into one command per beat; the
+    /// AppleScript queue is serial and slow enough to drown otherwise.
+    private var volumeSend: DispatchWorkItem?
+    /// The bundle id owning the session, whichever route — for `openPlayer`.
+    private var sourceBundleID: String?
     private var observers: [Any] = []
     /// Whether the panel is open — the ticker below runs only then.
     private var isActive = false
@@ -168,6 +181,42 @@ final class MediaController: ObservableObject {
 
     func previous() {
         dispatch(feed: .previous, script: { $0.previous() }, key: .previous)
+    }
+
+    func toggleShuffle() {
+        guard let activeConnector, let current = shuffle else { return }
+        shuffle = !current
+        activeConnector.setShuffle(!current)
+        verifySoon()
+    }
+
+    func cycleRepeat() {
+        guard let activeConnector, let current = repeatMode else { return }
+        let modes = activeConnector.supportedRepeatModes
+        let next = modes[((modes.firstIndex(of: current) ?? 0) + 1) % modes.count]
+        repeatMode = next
+        activeConnector.setRepeat(next)
+        verifySoon()
+    }
+
+    func setVolume(_ value: Int) {
+        guard let activeConnector else { return }
+        let clamped = min(max(0, value), 100)
+        volume = clamped
+        volumeHold = Date()
+        volumeSend?.cancel()
+        let work = DispatchWorkItem { activeConnector.setVolume(clamped) }
+        volumeSend = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: work)
+    }
+
+    /// The cover doubles as a door: clicking it raises whatever app owns the
+    /// session — a player, or the browser hosting the tab.
+    func openPlayer() {
+        guard let sourceBundleID,
+              let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: sourceBundleID)
+        else { return }
+        NSWorkspace.shared.openApplication(at: url, configuration: NSWorkspace.OpenConfiguration())
     }
 
     func seek(to seconds: TimeInterval) {
@@ -278,10 +327,18 @@ final class MediaController: ObservableObject {
     private func applyScripted(_ state: PlayerState) {
         if track?.key != state.key { noteTrackChanged() }
         sourceName = state.connector.displayName
+        sourceBundleID = state.connector.bundleID
         track = Track(title: state.title, artist: state.artist, album: state.album, key: state.key)
         isPlaying = state.isPlaying
         if state.duration > 0 { duration = state.duration }
         playbackRate = 1
+        shuffle = state.shuffle
+        repeatMode = state.repeatMode
+        // A reading taken mid-drag describes where the knob was, not where the
+        // finger is; local intent outranks it until the dust settles.
+        if volumeHold.map({ Date().timeIntervalSince($0) > 1.5 }) ?? true {
+            volume = state.volume
+        }
         adoptReported(state.position)
         updateTicker()
 
@@ -365,7 +422,12 @@ final class MediaController: ObservableObject {
         isPlaying = snapshot.isPlaying || snapshot.rate > 0
         duration = snapshot.duration
         sourceName = snapshot.source
+        sourceBundleID = snapshot.bundleID
         playbackRate = snapshot.rate > 0 ? snapshot.rate : 1
+        // No connector, no knobs: the pane hides what cannot be answered for.
+        volume = nil
+        shuffle = nil
+        repeatMode = nil
         // `livePosition`, never `elapsed`: the reading on its own is frozen at
         // the moment the player last published it, and taking it at face value
         // is what pinned the bar to 0:00 on a track minutes in.
@@ -465,6 +527,10 @@ final class MediaController: ObservableObject {
         noteTrackChanged()
         activeConnector = nil
         track = nil
+        sourceBundleID = nil
+        volume = nil
+        shuffle = nil
+        repeatMode = nil
         artwork = nil
         artworkKey = nil
         artworkUnavailable = false

--- a/Sources/Cyclop/Services/MediaController.swift
+++ b/Sources/Cyclop/Services/MediaController.swift
@@ -16,6 +16,10 @@ final class MediaController: ObservableObject {
 
     @Published private(set) var track: Track?
     @Published private(set) var artwork: NSImage?
+    /// True once every route to a cover has answered no — the pane switches
+    /// from skeleton to placeholder, because a shimmer that never resolves
+    /// reads as the app failing rather than the track having no art.
+    @Published private(set) var artworkUnavailable = false
     @Published private(set) var isPlaying = false
     @Published private(set) var duration: TimeInterval = 0
     @Published private(set) var position: TimeInterval = 0
@@ -24,12 +28,57 @@ final class MediaController: ObservableObject {
     private let feed = NowPlayingFeed()
     private var feedAvailable = true
 
-    private var activeApp: PlayerApp?
+    /// The connector for the app owning the session, when we have one.
+    /// Everything that can go through a connector does, because for those
+    /// players the system's own record is neither current nor commandable —
+    /// see `apply`.
+    private var activeConnector: (any PlayerConnector)?
     private var artworkKey: String?
+    /// Failed attempts for the current track, spacing the next try further out
+    /// each time. The poll arrives every second; without the spacing a dead
+    /// network would be asked for the same cover sixty times a minute, and
+    /// with a permanent give-up it would never be asked again even after the
+    /// network came back mid-track.
+    private var artworkRetries = 0
+    private var artworkRetryKey: String?
+    private var artworkRetryAt = Date.distantPast
+    /// Covers fetched this session, keyed by track. On a weak network a cover
+    /// is an achievement — walking prev/next must not throw it away and start
+    /// the shimmer over.
+    private var artworkCache: [String: NSImage] = [:]
+    private var artworkCacheOrder: [String] = []
+    /// The cover the system last published, kept aside by title. Local bytes,
+    /// already paid for: Spotify's own scripting interface refuses to hand
+    /// over image data (`artwork` is "deprecated and will never be set"), so
+    /// when the daemon's record does carry the picture it is the only way to
+    /// put a cover up without touching the network at all.
+    private var helperArtwork: (title: String, image: NSImage)?
     private var anchor: (position: TimeInterval, at: Date)?
-    /// Where we asked the player to jump, and when — see `apply`.
+    /// Speed the player reported, so a podcast at 1.5× does not walk away from
+    /// a bar that always counted at 1×.
+    private var playbackRate: Double = 1
+    /// Where we asked the player to jump, and when — see `adoptReported`.
     private var pendingSeek: (target: TimeInterval, at: Date)?
+    /// The previous reading, kept to tell whether the player's clock is
+    /// actually moving. Cleared after anything discontinuous — a track change,
+    /// our own seek — so the first comparison afterwards starts fresh.
+    private var lastReading: (position: TimeInterval, at: Date)?
+    /// True while the player claims to be playing but its reported position is
+    /// not moving: buffering, in practice. The player's "playing" means "I
+    /// intend to play", and on a weak connection intent can run ahead of audio
+    /// by many seconds. A bar that keeps counting through that is lying, and
+    /// worse, it gets yanked back on every correction — so while the player's
+    /// clock stands still, ours does too.
+    private var isStalled = false
     private var ticker: Timer?
+    /// Ordering for script answers: a response older than one already applied
+    /// is discarded. *Only* that — discarding merely-overtaken responses is a
+    /// trap, because queries go out once a second and a script that takes
+    /// longer than that to answer means every response arrives overtaken:
+    /// each one thrown away, the panel frozen on whatever it showed first.
+    private var queryCounter = 0
+    private var appliedQuery = 0
+    private var poller: Timer?
     private var observers: [Any] = []
     /// Whether the panel is open — the ticker below runs only then.
     private var isActive = false
@@ -48,6 +97,8 @@ final class MediaController: ObservableObject {
         observers.removeAll()
         ticker?.invalidate()
         ticker = nil
+        poller?.invalidate()
+        poller = nil
     }
 
     /// Panel visibility. The position ticker hangs off this: it exists to move
@@ -59,8 +110,14 @@ final class MediaController: ObservableObject {
     func setActive(_ active: Bool) {
         isActive = active
         updateTicker()
+        updatePoller()
         guard active else { return }
         tick()
+        refresh()
+    }
+
+    /// Asks whatever source is in use where things stand.
+    private func refresh() {
         if feedAvailable {
             feed.refresh()
         } else {
@@ -68,21 +125,49 @@ final class MediaController: ObservableObject {
         }
     }
 
+    /// The system is supposed to announce Now Playing changes, and the helper
+    /// forwards them when it gets them — but on macOS 26.5.2 it does not get
+    /// them: across repeated half-minute windows containing real track changes
+    /// and play/pause, not one notification arrived. Left waiting, the panel
+    /// shows whatever was true when it opened. So while it is open we ask,
+    /// twice a second being pointless for a record the player updates rarely
+    /// and once a second being enough to feel live.
+    private func updatePoller() {
+        poller?.invalidate()
+        poller = nil
+        guard isActive else { return }
+        let timer = Timer(timeInterval: 1, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refresh() }
+        }
+        timer.tolerance = 0.2
+        RunLoop.main.add(timer, forMode: .common)
+        poller = timer
+    }
+
+    /// A command needs a beat to reach the player and come back as fact. The
+    /// poller would catch it within the second anyway; this only shortens the
+    /// window in which the optimistic guess stands unverified.
+    private func verifySoon() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
+            self?.refresh()
+        }
+    }
+
     // MARK: - Transport
 
     func togglePlayPause() {
-        // Optimistic flip so the button feels instant; the feed corrects it.
+        // Optimistic flip so the button feels instant; the refresh corrects it.
         isPlaying.toggle()
         setAnchor(position)
-        dispatch(feed: .togglePlayPause, script: { PlayerBridge.playPause($0) }, key: .playPause)
+        dispatch(feed: .togglePlayPause, script: { $0.playPause() }, key: .playPause)
     }
 
     func next() {
-        dispatch(feed: .next, script: { PlayerBridge.next($0) }, key: .next)
+        dispatch(feed: .next, script: { $0.next() }, key: .next)
     }
 
     func previous() {
-        dispatch(feed: .previous, script: { PlayerBridge.previous($0) }, key: .previous)
+        dispatch(feed: .previous, script: { $0.previous() }, key: .previous)
     }
 
     func seek(to seconds: TimeInterval) {
@@ -90,62 +175,230 @@ final class MediaController: ObservableObject {
         let clamped = min(max(0, seconds), duration)
         setAnchor(clamped)
         pendingSeek = (clamped, Date())
-        if feedAvailable {
+        // The jump is discontinuous by design; comparing readings across it
+        // would read as either movement or a stall, and it is neither.
+        lastReading = nil
+        isStalled = false
+        // The connector first for the same reason as every other command
+        // below, and with more at stake: the system's seek is the one call
+        // that can leave things worse than it found them.
+        if let activeConnector {
+            activeConnector.seek(to: clamped)
+        } else if feedAvailable {
             feed.seek(to: clamped)
-        } else if let activeApp {
-            PlayerBridge.seek(activeApp, to: clamped)
         }
+        verifySoon()
     }
 
+    /// Order matters, and it is the reverse of what the layering suggests.
+    ///
+    /// The helper is the better *source* — it sees browser tabs and everything
+    /// else the system knows about, which no connector can reach. It is not the
+    /// better *remote*. On macOS 26.5.2 `MRMediaRemoteSendCommand` reports
+    /// success for every command and delivers none of them: play/pause leaves
+    /// the player playing, seek leaves the playhead where it was. The
+    /// connectors answer exactly, so when the session belongs to one of them
+    /// the command goes there and the helper is left to do what it is good at.
+    /// Anything else still goes through the helper, and a media key remains
+    /// the last resort for a session nothing else can address.
     private func dispatch(
         feed command: NowPlayingFeed.Command,
-        script: (PlayerApp) -> Void,
+        script: (any PlayerConnector) -> Void,
         key: PlayerBridge.MediaKey
     ) {
-        if feedAvailable {
+        if let activeConnector {
+            script(activeConnector)
+        } else if feedAvailable {
             feed.send(command)
-        } else if let activeApp {
-            script(activeApp)
         } else {
             PlayerBridge.postMediaKey(key.rawValue)
         }
+        verifySoon()
     }
 
     // MARK: - Feed
 
+    /// Routes the helper's record to whoever can be trusted with it.
+    ///
+    /// The helper is the only source that sees every session — browser tabs,
+    /// games, anything the system knows about — and for those it is also the
+    /// only source there is. For Apple Music and Spotify it is merely the one
+    /// that answers first. Its record for them lags: mid-test it was still
+    /// describing a song that had already finished, three minutes of playback
+    /// after the fact. So when it names one of those two as the owner, that is
+    /// the useful part of the answer, and the player itself is asked for the
+    /// rest.
     private func apply(_ snapshot: NowPlayingFeed.Snapshot) {
-        guard !snapshot.isEmpty else { return clear() }
+        // An empty record is not evidence of silence. On macOS 26.5.2 the
+        // daemon can miss a session entirely — Spotify freshly launched and
+        // audibly playing while the record stayed blank — so before showing
+        // "nothing is playing" the scriptable players get asked directly, and
+        // only their silence clears the pane.
+        guard !snapshot.isEmpty else { return refreshFromPlayers() }
 
+        // Whatever route the rest of the record takes, cover bytes are kept:
+        // the script path may want them the moment its own sources come back
+        // empty-handed.
+        if let data = snapshot.artwork { stashHelperArtwork(data, title: snapshot.title) }
+
+        guard let connector = PlayerConnectors.match(bundleID: snapshot.bundleID) else {
+            activeConnector = nil
+            return applyReported(snapshot)
+        }
+
+        activeConnector = connector
+        queryCounter += 1
+        let query = queryCounter
+        connector.state { [weak self] state in
+            guard let self, query > self.appliedQuery else { return }
+            self.appliedQuery = query
+            guard let state else {
+                // The player will not answer — automation refused, most likely.
+                // Fall back to the helper for the reading *and* for the
+                // transport, rather than keep aiming commands at a route that
+                // just failed. The next poll tries the player again.
+                self.activeConnector = nil
+                return self.applyReported(snapshot)
+            }
+            self.applyScripted(state)
+        }
+    }
+
+    /// Position bookkeeping that must not survive a change of track: a seek
+    /// aimed at the old track would hold the bar hostage against readings from
+    /// the new one, and a movement comparison across the boundary would call
+    /// the jump a stall or a sprint when it is neither.
+    private func noteTrackChanged() {
+        pendingSeek = nil
+        lastReading = nil
+        isStalled = false
+    }
+
+    /// Everything from a player that answered for itself.
+    private func applyScripted(_ state: PlayerState) {
+        if track?.key != state.key { noteTrackChanged() }
+        sourceName = state.connector.displayName
+        track = Track(title: state.title, artist: state.artist, album: state.album, key: state.key)
+        isPlaying = state.isPlaying
+        if state.duration > 0 { duration = state.duration }
+        playbackRate = 1
+        adoptReported(state.position)
+        updateTicker()
+
+        loadArtwork(for: state)
+    }
+
+    /// Keeps the cover in step with the track over a network that cannot be
+    /// counted on. Runs on every poll, so all it may do per call is one step:
+    /// serve the cache, start one fetch, or decline until the backoff passes.
+    private func loadArtwork(for state: PlayerState) {
+        // A cover the system already delivered for this same track goes
+        // straight into the cache — free, local, and not subject to the
+        // network being in a mood.
+        if artworkCache[state.key] == nil,
+           let stashed = helperArtwork, stashed.title == state.title {
+            artworkCache[state.key] = stashed.image
+            artworkCacheOrder.append(state.key)
+        }
+
+        if let cached = artworkCache[state.key] {
+            artworkKey = state.key
+            if artwork !== cached { artwork = cached }
+            artworkUnavailable = false
+            return
+        }
+
+        // Track changed: the old cover comes down right away, whatever state
+        // the previous fetch was in. Its late result is dropped by the
+        // retry-key guard in the completion below.
+        if artworkRetryKey != state.key {
+            artworkRetryKey = state.key
+            artworkRetries = 0
+            artworkRetryAt = .distantPast
+            artworkKey = nil
+            artwork = nil
+            artworkUnavailable = false
+        }
+
+        // Already in flight, or concluded hopeless, for this same track.
+        guard artworkKey != state.key else { return }
+
+        // Some tracks have no cover any route could reach — the connector
+        // knows which (Spotify local files, in practice). Nothing to retry.
+        if state.connector.artworkIsUnobtainable(for: state) {
+            artworkKey = state.key
+            artworkUnavailable = true
+            return
+        }
+
+        guard Date() >= artworkRetryAt else { return }
+        artworkKey = state.key
+        state.connector.artwork(for: state) { [weak self] image in
+            guard let self, self.artworkRetryKey == state.key else { return }
+            if let image {
+                self.artworkCache[state.key] = image
+                self.artworkCacheOrder.append(state.key)
+                if self.artworkCacheOrder.count > 12 {
+                    self.artworkCache.removeValue(forKey: self.artworkCacheOrder.removeFirst())
+                }
+                self.artworkKey = state.key
+                self.artwork = image
+                self.artworkUnavailable = false
+            } else {
+                // Not now — maybe later. The placeholder goes up immediately:
+                // tying the shimmer's lifetime to a slow network makes the app
+                // read as hung, while a placeholder that later resolves into
+                // the cover reads as the network being the network.
+                self.artworkRetries += 1
+                self.artworkUnavailable = true
+                self.artworkKey = nil
+                self.artworkRetryAt = Date().addingTimeInterval(min(60, Double(self.artworkRetries) * 5))
+            }
+        }
+    }
+
+    /// Everything from the helper, for a session nothing else can reach.
+    private func applyReported(_ snapshot: NowPlayingFeed.Snapshot) {
         let key = "\(snapshot.title)|\(snapshot.artist)|\(snapshot.album)"
+        if track?.key != key { noteTrackChanged() }
         track = Track(title: snapshot.title, artist: snapshot.artist, album: snapshot.album, key: key)
         isPlaying = snapshot.isPlaying || snapshot.rate > 0
         duration = snapshot.duration
         sourceName = snapshot.source
-
-        let reported = snapshot.livePosition
-
-        // A player needs a moment to act on a seek, and until it does it keeps
-        // reporting the old position. Accepting that would yank the bar back.
-        if let pending = pendingSeek {
-            let settled = abs(reported - pending.target) < 2.5
-            let expired = Date().timeIntervalSince(pending.at) > 1.5
-            if settled || expired {
-                pendingSeek = nil
-                adopt(reported)
-            }
-        } else {
-            adopt(reported)
-        }
+        playbackRate = snapshot.rate > 0 ? snapshot.rate : 1
+        // `livePosition`, never `elapsed`: the reading on its own is frozen at
+        // the moment the player last published it, and taking it at face value
+        // is what pinned the bar to 0:00 on a track minutes in.
+        adoptReported(snapshot.livePosition)
         updateTicker()
 
         if let data = snapshot.artwork {
             artworkKey = key
+            artworkUnavailable = false
             decodeArtwork(data, for: key)
         } else if artworkKey != key {
             // Track changed and the payload carried no artwork; the skeleton
             // covers the gap until the system publishes the new cover.
             artworkKey = key
             artwork = nil
+            artworkUnavailable = false
+        } else if artwork == nil {
+            // Second look at the same track and still nothing: the system has
+            // had its chance, stop shimmering. A later publish that does carry
+            // the cover still lands through the branch above.
+            artworkUnavailable = true
+        }
+    }
+
+    /// Decodes off-main and keeps the result by title, for `loadArtwork`.
+    private func stashHelperArtwork(_ data: Data, title: String) {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let rep = NSBitmapImageRep(data: data), let cgImage = rep.cgImage else { return }
+            let image = NSImage(
+                cgImage: cgImage,
+                size: NSSize(width: rep.pixelsWide, height: rep.pixelsHigh)
+            )
+            DispatchQueue.main.async { self?.helperArtwork = (title, image) }
         }
     }
 
@@ -165,11 +418,59 @@ final class MediaController: ObservableObject {
         }
     }
 
+    /// Gate in front of `adopt` for a position a source reported.
+    ///
+    /// A player needs a moment to act on a seek, and until it does it keeps
+    /// reporting the old position. Accepting that would yank the bar back to
+    /// where the drag started. The wait is generous because the cost of the two
+    /// mistakes is not symmetric: holding the bar a moment too long is
+    /// invisible, while dropping it back and returning is the rubber-band the
+    /// scrubber is judged on.
+    private func adoptReported(_ reported: TimeInterval) {
+        let now = Date()
+
+        // Is the player's own clock moving? Two readings a beat apart answer
+        // that; the stall flag freezes our ticker while the answer is no.
+        var moving = false
+        if let last = lastReading {
+            let dt = now.timeIntervalSince(last.at)
+            if dt >= 0.8 {
+                moving = abs(reported - last.position) >= 0.2 * dt
+                isStalled = isPlaying && !moving
+                lastReading = (reported, now)
+            } else {
+                moving = abs(reported - last.position) >= 0.1
+            }
+        } else {
+            lastReading = (reported, now)
+        }
+
+        if let pending = pendingSeek {
+            let age = now.timeIntervalSince(pending.at)
+            let settled = abs(reported - pending.target) < 2.5
+            // A frozen reading is not the player refusing the seek — it is the
+            // player buffering its way toward it, which on a weak connection
+            // takes as long as it takes. Only a reading moving somewhere else
+            // means the seek lost; a stuck one just extends the hold, up to a
+            // cap that stops a dead player from pinning the bar forever.
+            let overridden = age > 3 && moving && abs(reported - pending.target) >= 2.5
+            let gaveUp = age > 15
+            guard settled || overridden || gaveUp else { return }
+            pendingSeek = nil
+        }
+        adopt(reported)
+    }
+
     private func clear() {
-        activeApp = nil
+        noteTrackChanged()
+        activeConnector = nil
         track = nil
         artwork = nil
         artworkKey = nil
+        artworkUnavailable = false
+        artworkRetries = 0
+        artworkRetryKey = nil
+        artworkRetryAt = .distantPast
         isPlaying = false
         duration = 0
         position = 0
@@ -182,15 +483,15 @@ final class MediaController: ObservableObject {
     private func switchToScriptingFallback() {
         guard feedAvailable else { return }
         feedAvailable = false
-        NSLog("Cyclop: Now Playing helper unavailable, falling back to Music/Spotify scripting")
+        NSLog("Cyclop: Now Playing helper unavailable, falling back to player connectors")
 
         let center = DistributedNotificationCenter.default()
-        for app in PlayerApp.allCases {
+        for connector in PlayerConnectors.all {
             observers.append(center.addObserver(
-                forName: app.changeNotification, object: nil, queue: .main
+                forName: connector.changeNotification, object: nil, queue: .main
             ) { [weak self] _ in
                 MainActor.assumeIsolated {
-                    self?.activeApp = app
+                    self?.activeConnector = connector
                     self?.refreshFromPlayers()
                 }
             })
@@ -199,25 +500,11 @@ final class MediaController: ObservableObject {
     }
 
     private func refreshFromPlayers() {
-        PlayerBridge.currentState { [weak self] state in
+        PlayerConnectors.currentState { [weak self] state in
             guard let self else { return }
             guard let state else { return self.clear() }
-
-            self.activeApp = state.app
-            self.sourceName = state.app.displayName
-            self.track = Track(title: state.title, artist: state.artist, album: state.album, key: state.key)
-            self.isPlaying = state.isPlaying
-            self.duration = state.duration
-            self.adopt(state.position)
-            self.updateTicker()
-
-            guard self.artworkKey != state.key else { return }
-            self.artworkKey = state.key
-            self.artwork = nil
-            PlayerBridge.artwork(for: state) { [weak self] image in
-                guard let self, self.artworkKey == state.key else { return }
-                self.artwork = image
-            }
+            self.activeConnector = state.connector
+            self.applyScripted(state)
         }
     }
 
@@ -261,9 +548,14 @@ final class MediaController: ObservableObject {
     }
 
     private func updateTicker() {
+        // Idempotent: a reading now arrives every second, and tearing the timer
+        // down and building it back up each time would reset its phase on every
+        // one of them, leaving the bar to advance in uneven steps.
+        let shouldRun = isPlaying && isActive
+        guard shouldRun != (ticker != nil) else { return }
         ticker?.invalidate()
         ticker = nil
-        guard isPlaying, isActive else { return }
+        guard shouldRun else { return }
         // Four times a second: the bar advances in sub-pixel steps, so it reads
         // as smooth without any animation smoothing the seek away with it.
         let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
@@ -275,8 +567,11 @@ final class MediaController: ObservableObject {
     }
 
     private func tick() {
-        guard let anchor, isPlaying else { return }
-        let value = anchor.position + Date().timeIntervalSince(anchor.at)
+        guard let anchor, isPlaying, !isStalled else { return }
+        // Scaled by the rate: a podcast at 1.5× moves half again as far per
+        // second, and a bar that always counted at 1× would fall steadily
+        // behind and be dragged forward by every reading that corrected it.
+        let value = anchor.position + Date().timeIntervalSince(anchor.at) * playbackRate
         position = duration > 0 ? min(value, duration) : value
     }
 }

--- a/Sources/Cyclop/Services/MediaController.swift
+++ b/Sources/Cyclop/Services/MediaController.swift
@@ -122,7 +122,7 @@ final class MediaController: ObservableObject {
         duration = snapshot.duration
         sourceName = snapshot.source
 
-        let reported = reportedPosition(from: snapshot)
+        let reported = snapshot.livePosition
 
         // A player needs a moment to act on a seek, and until it does it keeps
         // reporting the old position. Accepting that would yank the bar back.
@@ -222,30 +222,6 @@ final class MediaController: ObservableObject {
     }
 
     // MARK: - Position
-
-    /// What a report actually says by the time it is read.
-    ///
-    /// MediaRemote does not keep the elapsed time running. The field is a
-    /// reading taken when the session last changed state, and the timestamp
-    /// beside it says when — a tab playing for three minutes keeps reporting
-    /// the second it started at, and many browsers report a plain zero. Taken
-    /// literally, every refresh describes the beginning of the track, and
-    /// `adopt` reads the gap as a seek made in the player and obeys it. Which
-    /// is exactly what hovering did: open the panel, refresh, bar to zero.
-    ///
-    /// So the reading is aged by the clock that came with it. A paused session
-    /// is left alone — its reading is not moving and there is nothing to add.
-    private func reportedPosition(from snapshot: NowPlayingFeed.Snapshot) -> TimeInterval {
-        guard snapshot.isPlaying || snapshot.rate > 0, let takenAt = snapshot.takenAt else {
-            return snapshot.elapsed
-        }
-        let since = Date().timeIntervalSince(takenAt)
-        // A stamp from the future is not a clock to add to. Trust the reading.
-        guard since >= 0 else { return snapshot.elapsed }
-        let rate = snapshot.rate > 0 ? snapshot.rate : 1
-        let aged = snapshot.elapsed + since * rate
-        return snapshot.duration > 0 ? min(aged, snapshot.duration) : aged
-    }
 
     private func setAnchor(_ value: TimeInterval) {
         position = value

--- a/Sources/Cyclop/Services/NowPlayingFeed.swift
+++ b/Sources/Cyclop/Services/NowPlayingFeed.swift
@@ -10,17 +10,40 @@ final class NowPlayingFeed {
         var artist = ""
         var album = ""
         var duration: TimeInterval = 0
+        /// Position **as of `stamped`**, not as of now. See `livePosition`.
         var elapsed: TimeInterval = 0
         var rate: Double = 0
-        /// When `elapsed` was read. MediaRemote reports a reading, not a
-        /// running clock — without this the reading cannot be aged.
-        var takenAt: Date?
+        /// When the player last told the system where it was. Absent only if
+        /// the record carried no timestamp, in which case `elapsed` has to be
+        /// taken at face value.
+        var stamped: Date?
+        /// When the helper read the record, so the wait in the pipe does not
+        /// get counted twice.
+        var read: Date = .init()
         /// Only present on the update where the track changed.
         var artwork: Data?
         /// Name of the app owning the session, resolved from its pid.
         var source: String?
+        /// Bundle id of that app — the transport uses it to decide whether the
+        /// owner is a player it can script.
+        var bundleID: String?
 
         var isEmpty: Bool { title.isEmpty }
+
+        /// Where the playhead stands now.
+        ///
+        /// `elapsed` is a reading taken at `stamped` and left there; the system
+        /// does not advance it, so on a track that has been playing a while it
+        /// is simply wrong — 0 while the song is three minutes in. The playhead
+        /// has moved by the time since that reading, scaled by the rate the
+        /// player reported, and that is what the bar has to be told.
+        var livePosition: TimeInterval {
+            guard let stamped else { return elapsed }
+            guard rate > 0 else { return elapsed }
+            let age = max(0, read.timeIntervalSince(stamped))
+            let value = elapsed + age * rate
+            return duration > 0 ? min(value, duration) : value
+        }
     }
 
     enum Command: Int {
@@ -116,7 +139,7 @@ final class NowPlayingFeed {
 
     func refresh() { write("get") }
     func send(_ command: Command) { write("cmd \(command.rawValue)") }
-    func seek(to seconds: TimeInterval) { write("seek \(Int(seconds))") }
+    func seek(to seconds: TimeInterval) { write(String(format: "seek %.3f", seconds)) }
 
     private func write(_ line: String) {
         guard let input, let data = (line + "\n").data(using: .utf8) else { return }
@@ -184,16 +207,23 @@ final class NowPlayingFeed {
         snapshot.duration = object["duration"] as? Double ?? 0
         snapshot.elapsed = object["elapsed"] as? Double ?? 0
         snapshot.rate = object["rate"] as? Double ?? 0
-        if let seconds = object["timestamp"] as? Double, seconds > 0 {
-            snapshot.takenAt = Date(timeIntervalSince1970: seconds)
+        if let stamp = object["timestamp"] as? Double, stamp > 0 {
+            snapshot.stamped = Date(timeIntervalSince1970: stamp)
         }
+        if let read = object["now"] as? Double, read > 0 {
+            snapshot.read = Date(timeIntervalSince1970: read)
+        }
+        // The size gate survives the merge: the helper feeds us over a pipe,
+        // and a runaway payload should be dropped, not decoded.
         if let base64 = object["artwork"] as? String,
            base64.count <= Self.maxArtworkBytes / 3 * 4 + 4,
            let artwork = Data(base64Encoded: base64), artwork.count <= Self.maxArtworkBytes {
             snapshot.artwork = artwork
         }
-        if let pid = object["pid"] as? Int, pid > 0 {
-            snapshot.source = NSRunningApplication(processIdentifier: pid_t(pid))?.localizedName
+        if let pid = object["pid"] as? Int, pid > 0,
+           let app = NSRunningApplication(processIdentifier: pid_t(pid)) {
+            snapshot.source = app.localizedName
+            snapshot.bundleID = app.bundleIdentifier
         }
         onUpdate?(snapshot)
     }

--- a/Sources/Cyclop/Services/PlayerBridge.swift
+++ b/Sources/Cyclop/Services/PlayerBridge.swift
@@ -1,109 +1,71 @@
 import AppKit
 
-/// Public-API bridge to the two scriptable players macOS ships with support
-/// for. Everything goes through AppleScript (state, artwork, transport) and
-/// distributed notifications (change events) — no private frameworks.
-enum PlayerApp: String, CaseIterable {
-    case music, spotify
-
-    var bundleID: String {
-        switch self {
-        case .music: return "com.apple.Music"
-        case .spotify: return "com.spotify.client"
-        }
-    }
-
-    var displayName: String {
-        switch self {
-        case .music: return "Apple Music"
-        case .spotify: return "Spotify"
-        }
-    }
-
-    /// Distributed notification the player posts on every state change.
-    var changeNotification: Notification.Name {
-        switch self {
-        case .music: return Notification.Name("com.apple.Music.playerInfo")
-        case .spotify: return Notification.Name("com.spotify.client.PlaybackStateChanged")
-        }
-    }
-
-    var isRunning: Bool {
-        !NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).isEmpty
-    }
-}
-
-struct PlayerState {
-    var app: PlayerApp
-    var isPlaying: Bool
-    var title: String
-    var artist: String
-    var album: String
-    var duration: TimeInterval
-    var position: TimeInterval
-    var artworkURL: URL?
-    /// Identity of the track, used to decide when artwork must be refetched.
-    var key: String { "\(app.rawValue)|\(title)|\(artist)|\(album)" }
-}
-
+/// Plumbing shared by every `PlayerConnector`: the AppleScript runner, the
+/// artwork network session, and the system media keys. Player-specific
+/// knowledge lives in the connectors themselves — see `Services/Players/`.
 enum PlayerBridge {
     private static let queue = DispatchQueue(label: "com.cyclop.applescript", qos: .utility)
 
-    // MARK: - State
+    // MARK: - AppleScript
 
-    static func state(of app: PlayerApp, completion: @escaping (PlayerState?) -> Void) {
-        guard app.isRunning else { return completion(nil) }
-        runScript(stateScript(for: app)) { descriptor in
-            guard let raw = descriptor?.stringValue, !raw.isEmpty else { return completion(nil) }
-            completion(parse(raw, app: app))
-        }
-    }
+    /// Compiled scripts, keyed by source. The state script runs every second
+    /// while the panel is open, and compiling it each time costs more than
+    /// running it — enough to push the round trip past the poll interval.
+    /// Touched only from `queue`, which also makes the non-thread-safe
+    /// `NSAppleScript` safe to reuse.
+    private static var compiled: [String: NSAppleScript] = [:]
 
-    /// Never launches a player: only already-running ones are queried, and a
-    /// playing app wins over a merely-open one.
-    static func currentState(completion: @escaping (PlayerState?) -> Void) {
-        let candidates = PlayerApp.allCases.filter(\.isRunning)
-        guard !candidates.isEmpty else { return completion(nil) }
-
-        var results: [PlayerState] = []
-        let group = DispatchGroup()
-        for app in candidates {
-            group.enter()
-            state(of: app) { state in
-                if let state { results.append(state) }
-                group.leave()
+    /// Shared AppleScript runner: one serial queue for every script the app sends.
+    static func runScript(_ source: String, completion: @escaping (NSAppleEventDescriptor?) -> Void) {
+        queue.async {
+            let script: NSAppleScript
+            if let cached = compiled[source] {
+                script = cached
+            } else if let fresh = NSAppleScript(source: source) {
+                compiled[source] = fresh
+                script = fresh
+            } else {
+                return DispatchQueue.main.async { completion(nil) }
             }
+            var error: NSDictionary?
+            let result = script.executeAndReturnError(&error)
+            if let error, let code = error[NSAppleScript.errorNumber] as? Int, code != 0 {
+                NSLog("Cyclop: AppleScript error \(code): \(error[NSAppleScript.errorMessage] ?? "")")
+            }
+            DispatchQueue.main.async { completion(result) }
         }
-        group.notify(queue: .main) {
-            completion(results.first(where: \.isPlaying) ?? results.first)
-        }
     }
 
-    // MARK: - Transport
+    // MARK: - Artwork network
 
-    static func playPause(_ app: PlayerApp) { command("playpause", on: app) }
-    static func next(_ app: PlayerApp) { command("next track", on: app) }
-    static func previous(_ app: PlayerApp) {
-        // Spotify's `previous track` restarts the current song first, matching
-        // its own UI; Music behaves the same way. Seeking to 0 first is what
-        // users expect from a "skip back" button.
-        command(app == .spotify ? "set player position to 0\n    previous track" : "back track", on: app)
+    /// Session for cover fetches. The shared session waits a minute before
+    /// giving up, and on a weak network — or one where Spotify's CDN stalls at
+    /// the TLS handshake, which happens — that minute is spent shimmering a
+    /// skeleton at the user. Covers are small: if one has not arrived in
+    /// seconds, it is not arriving, and the retry loop upstream should hear
+    /// about it while the track is still playing.
+    static let artworkSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 6
+        config.timeoutIntervalForResource = 12
+        return URLSession(configuration: config)
+    }()
+
+    /// The only thing the app ever fetches over the network. Addresses come
+    /// out of another app's scripting dictionary, so the scheme is checked:
+    /// https answers for itself through TLS, while file:// or some private
+    /// scheme answers to nobody.
+    static func fetchImage(_ url: URL, completion: @escaping (NSImage?) -> Void) {
+        guard url.scheme?.lowercased() == "https" else { return completion(nil) }
+        artworkSession.dataTask(with: url) { data, _, _ in
+            let image = data.flatMap(NSImage.init(data:))
+            DispatchQueue.main.async { completion(image) }
+        }.resume()
     }
 
-    static func seek(_ app: PlayerApp, to seconds: TimeInterval) {
-        command("set player position to \(Int(seconds))", on: app)
-    }
+    // MARK: - Media keys
 
-    private static func command(_ body: String, on app: PlayerApp) {
-        guard app.isRunning else { return }
-        runScript("""
-        tell application id "\(app.bundleID)"
-            \(body)
-        end tell
-        """) { _ in }
-    }
-
-    /// System-wide media key, used when no scriptable player is running.
+    /// System-wide media key, used when no addressable player owns the session.
     /// Requires Accessibility permission; silently does nothing without it.
     static func postMediaKey(_ key: Int32) {
         for down in [true, false] {
@@ -125,105 +87,5 @@ enum PlayerBridge {
 
     enum MediaKey: Int32 {
         case playPause = 16, next = 17, previous = 18
-    }
-
-    // MARK: - Artwork
-
-    static func artwork(for state: PlayerState, completion: @escaping (NSImage?) -> Void) {
-        switch state.app {
-        case .spotify:
-            // The one thing the app ever fetches over the network. The address
-            // comes out of another app's scripting dictionary, so the scheme is
-            // checked: https answers for itself through TLS, while file:// or
-            // some private scheme answers to nobody.
-            guard let url = state.artworkURL, url.scheme?.lowercased() == "https" else {
-                return completion(nil)
-            }
-            URLSession.shared.dataTask(with: url) { data, _, _ in
-                let image = data.flatMap(NSImage.init(data:))
-                DispatchQueue.main.async { completion(image) }
-            }.resume()
-        case .music:
-            runScript("""
-            tell application id "com.apple.Music"
-                if (count of artworks of current track) is 0 then return missing value
-                return raw data of artwork 1 of current track
-            end tell
-            """) { descriptor in
-                guard let data = descriptor?.data, !data.isEmpty else { return completion(nil) }
-                completion(NSImage(data: data))
-            }
-        }
-    }
-
-    // MARK: - Scripts
-
-    private static func stateScript(for app: PlayerApp) -> String {
-        let sep = "set sep to character id 1"
-        switch app {
-        case .spotify:
-            return """
-            \(sep)
-            tell application id "com.spotify.client"
-                try
-                    set st to player state as text
-                    set t to current track
-                    try
-                        set pos to (round ((player position) * 1000))
-                    on error
-                        set pos to 0
-                    end try
-                    return st & sep & (name of t) & sep & (artist of t) & sep & (album of t) & sep & (duration of t) & sep & pos & sep & (artwork url of t)
-                on error
-                    return ""
-                end try
-            end tell
-            """
-        case .music:
-            return """
-            \(sep)
-            tell application id "com.apple.Music"
-                try
-                    set st to player state as text
-                    set t to current track
-                    try
-                        set pos to (round ((player position) * 1000))
-                    on error
-                        set pos to 0
-                    end try
-                    return st & sep & (name of t) & sep & (artist of t) & sep & (album of t) & sep & (round ((duration of t) * 1000)) & sep & pos & sep & ""
-                on error
-                    return ""
-                end try
-            end tell
-            """
-        }
-    }
-
-    private static func parse(_ raw: String, app: PlayerApp) -> PlayerState? {
-        let parts = raw.components(separatedBy: "\u{1}")
-        guard parts.count >= 6, !parts[1].isEmpty else { return nil }
-        return PlayerState(
-            app: app,
-            isPlaying: parts[0].lowercased() == "playing",
-            title: parts[1],
-            artist: parts[2],
-            album: parts[3],
-            duration: (Double(parts[4]) ?? 0) / 1000,
-            position: (Double(parts[5]) ?? 0) / 1000,
-            artworkURL: parts.count > 6 ? URL(string: parts[6]) : nil
-        )
-    }
-
-    /// Shared AppleScript runner: one serial queue for every script the app sends.
-    static func runScript(_ source: String, completion: @escaping (NSAppleEventDescriptor?) -> Void) {
-        queue.async {
-            var error: NSDictionary?
-            let result = NSAppleScript(source: source)?.executeAndReturnError(&error)
-            if let error, let code = error[NSAppleScript.errorNumber] as? Int, code != 0 {
-                NSLog("Cyclop: AppleScript error \(code): \(error[NSAppleScript.errorMessage] ?? "")")
-            }
-            DispatchQueue.main.async { completion(result) }
-        }
     }
 }

--- a/Sources/Cyclop/Services/Players/MusicConnector.swift
+++ b/Sources/Cyclop/Services/Players/MusicConnector.swift
@@ -20,7 +20,7 @@ struct MusicConnector: PlayerConnector {
                 on error
                     set posMillis to 0
                 end try
-                return stateText & sep & (name of theTrack) & sep & (artist of theTrack) & sep & (album of theTrack) & sep & (round ((duration of theTrack) * 1000)) & sep & posMillis & sep & "" & sep & ""
+                return stateText & sep & (name of theTrack) & sep & (artist of theTrack) & sep & (album of theTrack) & sep & (round ((duration of theTrack) * 1000)) & sep & posMillis & sep & "" & sep & "" & sep & (sound volume as text) & sep & (shuffle enabled as text) & sep & (song repeat as text)
             on error
                 return ""
             end try
@@ -31,6 +31,9 @@ struct MusicConnector: PlayerConnector {
     func playPause() { command("playpause") }
     func next() { command("next track") }
     func previous() { command("back track") }
+    func setShuffle(_ enabled: Bool) { command("set shuffle enabled to \(enabled)") }
+    func setRepeat(_ mode: RepeatMode) { command("set song repeat to \(mode.rawValue)") }
+    var supportedRepeatModes: [RepeatMode] { [.off, .all, .one] }
 
     /// Music, unlike Spotify, hands the actual bytes over — no network at all.
     func artwork(for state: PlayerState, completion: @escaping (NSImage?) -> Void) {

--- a/Sources/Cyclop/Services/Players/MusicConnector.swift
+++ b/Sources/Cyclop/Services/Players/MusicConnector.swift
@@ -1,0 +1,47 @@
+import AppKit
+
+struct MusicConnector: PlayerConnector {
+    let bundleID = "com.apple.Music"
+    let displayName = "Apple Music"
+    var changeNotification: Notification.Name {
+        Notification.Name("com.apple.Music.playerInfo")
+    }
+
+    // See SpotifyConnector for why the variable names are wordy.
+    func state(completion: @escaping (PlayerState?) -> Void) {
+        runStateScript("""
+        set sep to character id 1
+        tell application id "com.apple.Music"
+            try
+                set stateText to player state as text
+                set theTrack to current track
+                try
+                    set posMillis to (round ((player position) * 1000))
+                on error
+                    set posMillis to 0
+                end try
+                return stateText & sep & (name of theTrack) & sep & (artist of theTrack) & sep & (album of theTrack) & sep & (round ((duration of theTrack) * 1000)) & sep & posMillis & sep & "" & sep & ""
+            on error
+                return ""
+            end try
+        end tell
+        """, completion: completion)
+    }
+
+    func playPause() { command("playpause") }
+    func next() { command("next track") }
+    func previous() { command("back track") }
+
+    /// Music, unlike Spotify, hands the actual bytes over — no network at all.
+    func artwork(for state: PlayerState, completion: @escaping (NSImage?) -> Void) {
+        PlayerBridge.runScript("""
+        tell application id "com.apple.Music"
+            if (count of artworks of current track) is 0 then return missing value
+            return raw data of artwork 1 of current track
+        end tell
+        """) { descriptor in
+            guard let data = descriptor?.data, !data.isEmpty else { return completion(nil) }
+            completion(NSImage(data: data))
+        }
+    }
+}

--- a/Sources/Cyclop/Services/Players/PlayerConnector.swift
+++ b/Sources/Cyclop/Services/Players/PlayerConnector.swift
@@ -1,0 +1,138 @@
+import AppKit
+
+/// A player the app can address directly — ask where it stands, tell it what
+/// to do — instead of trusting the system's Now Playing record, which on
+/// current macOS is neither current nor commandable (see `MediaController`).
+///
+/// The record still *discovers* sessions: it is the only thing that sees
+/// browser tabs and everything else. A connector is what makes a session
+/// exact once the record names an owner we know how to talk to. Adding a
+/// player is one conforming type plus a line in `PlayerConnectors.all`.
+@MainActor
+protocol PlayerConnector {
+    /// Matched against the bundle id of the app owning the Now Playing session.
+    /// Nonisolated: identity is immutable and read from value types like
+    /// `PlayerState.key` that carry no actor context of their own.
+    nonisolated var bundleID: String { get }
+    nonisolated var displayName: String { get }
+    /// Distributed notification the player posts on every state change; the
+    /// no-helper fallback listens to these instead of polling blind.
+    var changeNotification: Notification.Name { get }
+
+    func state(completion: @escaping (PlayerState?) -> Void)
+    func playPause()
+    func next()
+    func previous()
+    func seek(to seconds: TimeInterval)
+    func artwork(for state: PlayerState, completion: @escaping (NSImage?) -> Void)
+    /// True when no route to a cover exists for this track at all, so the
+    /// caller can settle for a placeholder at once instead of retrying a fetch
+    /// that cannot succeed. Defaults to false.
+    func artworkIsUnobtainable(for state: PlayerState) -> Bool
+}
+
+extension PlayerConnector {
+    func artworkIsUnobtainable(for state: PlayerState) -> Bool { false }
+}
+
+struct PlayerState {
+    let connector: any PlayerConnector
+    var isPlaying: Bool
+    var title: String
+    var artist: String
+    var album: String
+    var duration: TimeInterval
+    var position: TimeInterval
+    var artworkURL: URL?
+    /// The player's own id for the track, when it has one — the way back to
+    /// artwork when `artworkURL` is not (see `SpotifyConnector.artwork`).
+    var trackID: String?
+    /// Identity of the track, used to decide when artwork must be refetched.
+    var key: String { "\(connector.bundleID)|\(title)|\(artist)|\(album)" }
+}
+
+extension PlayerConnector {
+    var isRunning: Bool {
+        !NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).isEmpty
+    }
+
+    /// Sends a transport command; never launches the player to do it.
+    func command(_ body: String) {
+        guard isRunning else { return }
+        PlayerBridge.runScript("""
+        tell application id "\(bundleID)"
+            \(body)
+        end tell
+        """) { _ in }
+    }
+
+    func seek(to seconds: TimeInterval) {
+        // Players take a real here. Rounding to the second would put the
+        // playhead up to half a second from where the cursor was let go, which
+        // on a short track is a visible distance along the bar.
+        command(String(format: "set player position to %.3f", seconds))
+    }
+
+    /// Runs a state script and parses its answer. Both bundled connectors emit
+    /// the same sep-separated shape — state, name, artist, album, duration in
+    /// ms, position in ms, artwork url, track id — so the parsing lives here.
+    func runStateScript(_ source: String, completion: @escaping (PlayerState?) -> Void) {
+        guard isRunning else { return completion(nil) }
+        PlayerBridge.runScript(source) { descriptor in
+            guard let raw = descriptor?.stringValue, !raw.isEmpty else { return completion(nil) }
+            completion(parseState(raw))
+        }
+    }
+
+    private func parseState(_ raw: String) -> PlayerState? {
+        let parts = raw.components(separatedBy: "\u{1}")
+        guard parts.count >= 6, !parts[1].isEmpty else { return nil }
+        // AppleScript folds `missing value` into the concatenation as those two
+        // literal words, and lenient URL parsing would happily wrap them into a
+        // URL and send a doomed request. Only an actual address counts.
+        var artworkURL: URL?
+        if parts.count > 6, parts[6].hasPrefix("http") { artworkURL = URL(string: parts[6]) }
+        return PlayerState(
+            connector: self,
+            isPlaying: parts[0].lowercased() == "playing",
+            title: parts[1],
+            artist: parts[2],
+            album: parts[3],
+            duration: (Double(parts[4]) ?? 0) / 1000,
+            position: (Double(parts[5]) ?? 0) / 1000,
+            artworkURL: artworkURL,
+            trackID: parts.count > 7 && !parts[7].isEmpty ? parts[7] : nil
+        )
+    }
+}
+
+/// The players Cyclop knows how to talk to.
+@MainActor
+enum PlayerConnectors {
+    static let all: [any PlayerConnector] = [MusicConnector(), SpotifyConnector()]
+
+    static func match(bundleID: String?) -> (any PlayerConnector)? {
+        guard let bundleID else { return nil }
+        return all.first { $0.bundleID == bundleID }
+    }
+
+    /// Asks every running player at once; a playing one wins over a merely
+    /// open one. Never launches anything.
+    static func currentState(completion: @escaping (PlayerState?) -> Void) {
+        let candidates = all.filter(\.isRunning)
+        guard !candidates.isEmpty else { return completion(nil) }
+
+        var results: [PlayerState] = []
+        let group = DispatchGroup()
+        for connector in candidates {
+            group.enter()
+            connector.state { state in
+                if let state { results.append(state) }
+                group.leave()
+            }
+        }
+        group.notify(queue: .main) {
+            completion(results.first(where: \.isPlaying) ?? results.first)
+        }
+    }
+}

--- a/Sources/Cyclop/Services/Players/PlayerConnector.swift
+++ b/Sources/Cyclop/Services/Players/PlayerConnector.swift
@@ -24,6 +24,14 @@ protocol PlayerConnector {
     func next()
     func previous()
     func seek(to seconds: TimeInterval)
+    /// Player volume, 0–100 — the player's own, deliberately not the system's:
+    /// turning music down should not turn a video call down with it.
+    func setVolume(_ volume: Int)
+    func setShuffle(_ enabled: Bool)
+    func setRepeat(_ mode: RepeatMode)
+    /// The modes this player can express, in the order a toggle should walk
+    /// them. Spotify's scripting has no repeat-one; Music has all three.
+    var supportedRepeatModes: [RepeatMode] { get }
     func artwork(for state: PlayerState, completion: @escaping (NSImage?) -> Void)
     /// True when no route to a cover exists for this track at all, so the
     /// caller can settle for a placeholder at once instead of retrying a fetch
@@ -31,8 +39,14 @@ protocol PlayerConnector {
     func artworkIsUnobtainable(for state: PlayerState) -> Bool
 }
 
+enum RepeatMode: String {
+    case off, all, one
+}
+
 extension PlayerConnector {
     func artworkIsUnobtainable(for state: PlayerState) -> Bool { false }
+    func setVolume(_ volume: Int) { command("set sound volume to \(min(max(0, volume), 100))") }
+    var supportedRepeatModes: [RepeatMode] { [.off, .all] }
 }
 
 struct PlayerState {
@@ -47,6 +61,11 @@ struct PlayerState {
     /// The player's own id for the track, when it has one — the way back to
     /// artwork when `artworkURL` is not (see `SpotifyConnector.artwork`).
     var trackID: String?
+    /// Player volume 0–100. Optional because a session without a connector
+    /// has no volume anyone can read — the pane hides the slider then.
+    var volume: Int?
+    var shuffle: Bool?
+    var repeatMode: RepeatMode?
     /// Identity of the track, used to decide when artwork must be refetched.
     var key: String { "\(connector.bundleID)|\(title)|\(artist)|\(album)" }
 }
@@ -75,7 +94,8 @@ extension PlayerConnector {
 
     /// Runs a state script and parses its answer. Both bundled connectors emit
     /// the same sep-separated shape — state, name, artist, album, duration in
-    /// ms, position in ms, artwork url, track id — so the parsing lives here.
+    /// ms, position in ms, artwork url, track id, volume, shuffle, repeat — so
+    /// the parsing lives here.
     func runStateScript(_ source: String, completion: @escaping (PlayerState?) -> Void) {
         guard isRunning else { return completion(nil) }
         PlayerBridge.runScript(source) { descriptor in
@@ -92,6 +112,16 @@ extension PlayerConnector {
         // URL and send a doomed request. Only an actual address counts.
         var artworkURL: URL?
         if parts.count > 6, parts[6].hasPrefix("http") { artworkURL = URL(string: parts[6]) }
+        // Repeat arrives as the player expresses it: Spotify's boolean
+        // ("true"/"false"), Music's constant ("off"/"one"/"all").
+        var repeatMode: RepeatMode?
+        if parts.count > 10 {
+            switch parts[10] {
+            case "true": repeatMode = .all
+            case "false": repeatMode = .off
+            default: repeatMode = RepeatMode(rawValue: parts[10])
+            }
+        }
         return PlayerState(
             connector: self,
             isPlaying: parts[0].lowercased() == "playing",
@@ -101,7 +131,10 @@ extension PlayerConnector {
             duration: (Double(parts[4]) ?? 0) / 1000,
             position: (Double(parts[5]) ?? 0) / 1000,
             artworkURL: artworkURL,
-            trackID: parts.count > 7 && !parts[7].isEmpty ? parts[7] : nil
+            trackID: parts.count > 7 && !parts[7].isEmpty ? parts[7] : nil,
+            volume: parts.count > 8 ? Int(parts[8]) : nil,
+            shuffle: parts.count > 9 && !parts[9].isEmpty ? parts[9] == "true" : nil,
+            repeatMode: repeatMode
         )
     }
 }

--- a/Sources/Cyclop/Services/Players/SpotifyConnector.swift
+++ b/Sources/Cyclop/Services/Players/SpotifyConnector.swift
@@ -1,0 +1,116 @@
+import AppKit
+
+struct SpotifyConnector: PlayerConnector {
+    let bundleID = "com.spotify.client"
+    let displayName = "Spotify"
+    var changeNotification: Notification.Name {
+        Notification.Name("com.spotify.client.PlaybackStateChanged")
+    }
+
+    // Variable names are deliberately wordy: on macOS 26 `st` became a reserved
+    // token — `set st to …` is a syntax error (-2741) even outside any tell
+    // block — and a script that does not compile reads as a player that does
+    // not answer. Short names are one OS update away from being stolen.
+    func state(completion: @escaping (PlayerState?) -> Void) {
+        runStateScript("""
+        set sep to character id 1
+        tell application id "com.spotify.client"
+            try
+                set stateText to player state as text
+                set theTrack to current track
+                try
+                    set posMillis to (round ((player position) * 1000))
+                on error
+                    set posMillis to 0
+                end try
+                return stateText & sep & (name of theTrack) & sep & (artist of theTrack) & sep & (album of theTrack) & sep & (duration of theTrack) & sep & posMillis & sep & (artwork url of theTrack) & sep & (id of theTrack)
+            on error
+                return ""
+            end try
+        end tell
+        """, completion: completion)
+    }
+
+    func playPause() { command("playpause") }
+    func next() { command("next track") }
+
+    func previous() {
+        // Spotify's `previous track` restarts the current song first, matching
+        // its own UI. Seeking to 0 first is what users expect from a "skip
+        // back" button.
+        command("set player position to 0\n    previous track")
+    }
+
+    /// Session memory for the primary artwork host. `artwork url` points at
+    /// i.scdn.co; the oEmbed thumbnail lives on a different CDN, and networks
+    /// exist where the first is unreachable while the second is fine. Once
+    /// that is established there is no reason to pay a six-second timeout on
+    /// every new track — the primary is skipped, and probed again after a
+    /// while in case the network changed (a VPN toggled, a Wi-Fi switch): it
+    /// serves the larger image, so it is worth taking back.
+    ///
+    /// The host is condemned only when the fallback *succeeds* right after it
+    /// failed — that is what separates "this host is blocked" from "there is
+    /// no network", which no host should be blamed for.
+    @MainActor
+    private enum PrimaryArtworkHost {
+        static var downSince: Date?
+        static let probeAfter: TimeInterval = 600
+        static var worthTrying: Bool {
+            guard let downSince else { return true }
+            return Date().timeIntervalSince(downSince) > probeAfter
+        }
+    }
+
+    /// Spotify answers `artwork url` with missing value more often than it
+    /// should — always for local files, and sporadically for catalog tracks.
+    /// Image *data* it refuses to hand over at all: the `artwork` property is
+    /// "deprecated and will never be set". For a catalog track the cover is
+    /// also reachable through the public oEmbed endpoint by the track's own
+    /// id — the route taken when the URL is missing, when its host has been
+    /// found dead this session, and when a fresh attempt on it fails. A local
+    /// file's cover exists only inside Spotify's window; for it the honest
+    /// answer is nil, which the pane shows as a placeholder rather than a
+    /// skeleton that never resolves.
+    func artwork(for state: PlayerState, completion: @escaping (NSImage?) -> Void) {
+        guard let url = state.artworkURL, PrimaryArtworkHost.worthTrying else {
+            return Self.fetchViaOEmbed(state, completion: completion)
+        }
+        PlayerBridge.fetchImage(url) { image in
+            MainActor.assumeIsolated {
+                if let image {
+                    PrimaryArtworkHost.downSince = nil
+                    return completion(image)
+                }
+                let failedAt = Date()
+                Self.fetchViaOEmbed(state) { fallback in
+                    MainActor.assumeIsolated {
+                        if fallback != nil { PrimaryArtworkHost.downSince = failedAt }
+                        completion(fallback)
+                    }
+                }
+            }
+        }
+    }
+
+    private static func fetchViaOEmbed(_ state: PlayerState, completion: @escaping (NSImage?) -> Void) {
+        guard let id = state.trackID, id.hasPrefix("spotify:track:"),
+              let oembed = URL(string: "https://open.spotify.com/oembed?url=\(id)") else {
+            return completion(nil)
+        }
+        PlayerBridge.artworkSession.dataTask(with: oembed) { data, _, _ in
+            guard let data,
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let thumbnail = object["thumbnail_url"] as? String,
+                  let url = URL(string: thumbnail)
+            else { return DispatchQueue.main.async { completion(nil) } }
+            PlayerBridge.fetchImage(url, completion: completion)
+        }.resume()
+    }
+
+    /// A local file's cover exists only inside Spotify's window: no URL, no
+    /// catalog id to look it up by, nothing any retry could change.
+    func artworkIsUnobtainable(for state: PlayerState) -> Bool {
+        state.artworkURL == nil && !(state.trackID?.hasPrefix("spotify:track:") ?? false)
+    }
+}

--- a/Sources/Cyclop/Services/Players/SpotifyConnector.swift
+++ b/Sources/Cyclop/Services/Players/SpotifyConnector.swift
@@ -23,7 +23,7 @@ struct SpotifyConnector: PlayerConnector {
                 on error
                     set posMillis to 0
                 end try
-                return stateText & sep & (name of theTrack) & sep & (artist of theTrack) & sep & (album of theTrack) & sep & (duration of theTrack) & sep & posMillis & sep & (artwork url of theTrack) & sep & (id of theTrack)
+                return stateText & sep & (name of theTrack) & sep & (artist of theTrack) & sep & (album of theTrack) & sep & (duration of theTrack) & sep & posMillis & sep & (artwork url of theTrack) & sep & (id of theTrack) & sep & (sound volume as text) & sep & (shuffling as text) & sep & (repeating as text)
             on error
                 return ""
             end try
@@ -33,6 +33,10 @@ struct SpotifyConnector: PlayerConnector {
 
     func playPause() { command("playpause") }
     func next() { command("next track") }
+    func setShuffle(_ enabled: Bool) { command("set shuffling to \(enabled)") }
+    /// Spotify's scripting exposes repeat as a boolean, so `.one` cannot be
+    /// asked for — `supportedRepeatModes` keeps it out of the cycle.
+    func setRepeat(_ mode: RepeatMode) { command("set repeating to \(mode != .off)") }
 
     func previous() {
         // Spotify's `previous track` restarts the current song first, matching

--- a/Sources/Cyclop/UI/MediaPane.swift
+++ b/Sources/Cyclop/UI/MediaPane.swift
@@ -6,6 +6,13 @@ struct MediaPane: View {
     @State private var scrubHover = false
     /// Set while dragging, so the bar follows the finger instead of the clock.
     @State private var scrubbing: Double?
+    /// The transport row yields to the volume slider while this is set —
+    /// hovering the speaker opens it, leaving the row closes it. One row,
+    /// two duties, never both at once.
+    @State private var volumeExpanded = false
+    /// Total ↔ remaining on the right-hand timer; survives restarts because a
+    /// preference this small should not need re-teaching.
+    @AppStorage("mediaShowRemaining") private var showRemaining = false
 
     /// Artwork and the text column share this height, so their top and bottom
     /// edges line up instead of the column floating past them.
@@ -83,6 +90,8 @@ struct MediaPane: View {
         )
         .shadow(color: .black.opacity(0.5), radius: 12, y: 5)
         .animation(Theme.artworkAnimation, value: media.artwork)
+        // The cover is the door to the app that is playing.
+        .onTapGesture { media.openPlayer() }
     }
 
     // MARK: - Scrubber
@@ -142,8 +151,13 @@ struct MediaPane: View {
             }
             .frame(height: 14)
 
-            Text(formatTime(media.duration))
-                .frame(width: 32, alignment: .trailing)
+            // Total by default, remaining on click — the countdown DJs watch.
+            Text(showRemaining
+                 ? "-" + formatTime(max(0, media.duration - progress * media.duration))
+                 : formatTime(media.duration))
+                .frame(width: 36, alignment: .trailing)
+                .contentShape(Rectangle())
+                .onTapGesture { showRemaining.toggle() }
         }
         .font(.system(size: 10, weight: .medium).monospacedDigit())
         .foregroundStyle(Theme.tertiary)
@@ -152,7 +166,27 @@ struct MediaPane: View {
     // MARK: - Transport
 
     private var controls: some View {
-        HStack(spacing: 20) {
+        ZStack {
+            if volumeExpanded, media.volume != nil {
+                expandedVolume.transition(.opacity)
+            } else {
+                transportRow.transition(.opacity)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 40)
+        // The container spans both faces of the row, so leaving it always
+        // folds the slider back — including the case where the swap happened
+        // under a cursor that then left without ever touching the slider.
+        .onHover { inside in if !inside { volumeExpanded = false } }
+        .animation(Theme.contentAnimation, value: volumeExpanded)
+    }
+
+    private var transportRow: some View {
+        HStack(spacing: 16) {
+            if media.shuffle != nil {
+                modeToggle("shuffle", active: media.shuffle == true) { media.toggleShuffle() }
+            }
             Button { media.previous() } label: { Image(systemName: "backward.fill") }
                 .buttonStyle(NotchButtonStyle(size: 30))
             Button { media.togglePlayPause() } label: {
@@ -161,8 +195,88 @@ struct MediaPane: View {
             .buttonStyle(NotchButtonStyle(size: 40, prominent: true))
             Button { media.next() } label: { Image(systemName: "forward.fill") }
                 .buttonStyle(NotchButtonStyle(size: 30))
+            if let mode = media.repeatMode {
+                modeToggle(mode == .one ? "repeat.1" : "repeat", active: mode != .off) {
+                    media.cycleRepeat()
+                }
+            }
+            if media.volume != nil {
+                Image(systemName: volumeIcon)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Theme.tertiary)
+                    .frame(width: 24, height: 24)
+                    .contentShape(Rectangle())
+                    .onHover { inside in if inside { volumeExpanded = true } }
+            }
         }
-        .frame(maxWidth: .infinity)
+    }
+
+    /// Shuffle and repeat: quieter than transport, lit when engaged.
+    private func modeToggle(_ system: String, active: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: system)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(active ? .white : Theme.tertiary)
+                .frame(width: 24, height: 24)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Volume
+
+    /// What the transport row becomes while the speaker is hovered: one wide
+    /// slider with the level spelled out, gone the moment the cursor leaves.
+    private var expandedVolume: some View {
+        HStack(spacing: 10) {
+            Image(systemName: volumeIcon)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 24)
+
+            GeometryReader { geo in
+                let width = geo.size.width
+                let level = Double(media.volume ?? 0) / 100
+                let filled = width * level
+
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Theme.surface).frame(height: 5)
+                    Capsule()
+                        .fill(Color.white.opacity(0.9))
+                        .frame(width: filled, height: 5)
+                    Circle()
+                        .fill(.white)
+                        .frame(width: 11, height: 11)
+                        .offset(x: min(max(filled - 5.5, 0), max(width - 11, 0)))
+                        .shadow(color: .black.opacity(0.4), radius: 3)
+                }
+                .frame(maxHeight: .infinity)
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { value in
+                            guard width > 0 else { return }
+                            media.setVolume(Int(min(max(value.location.x / width, 0), 1) * 100))
+                        }
+                )
+            }
+            .frame(height: 24)
+
+            Text("\(media.volume ?? 0)")
+                .font(.system(size: 10, weight: .medium).monospacedDigit())
+                .foregroundStyle(Theme.tertiary)
+                .frame(width: 24, alignment: .trailing)
+        }
+        .padding(.horizontal, 4)
+    }
+
+    private var volumeIcon: String {
+        switch media.volume ?? 0 {
+        case 0: return "speaker.slash.fill"
+        case ..<34: return "speaker.wave.1.fill"
+        case ..<67: return "speaker.wave.2.fill"
+        default: return "speaker.wave.3.fill"
+        }
     }
 
     private var emptyState: some View {

--- a/Sources/Cyclop/UI/MediaPane.swift
+++ b/Sources/Cyclop/UI/MediaPane.swift
@@ -59,6 +59,18 @@ struct MediaPane: View {
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .transition(.opacity)
+            } else if media.artworkUnavailable {
+                // No cover exists anywhere for this track (Spotify local files,
+                // mostly). A skeleton here would shimmer forever and read as a
+                // bug; a quiet glyph reads as the truth.
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Theme.surface)
+                    .overlay(
+                        Image(systemName: "music.note")
+                            .font(.system(size: 30, weight: .light))
+                            .foregroundStyle(Theme.tertiary)
+                    )
+                    .transition(.opacity)
             } else {
                 SkeletonBox(cornerRadius: 14)
             }

--- a/Sources/CyclopMediaHelper/helper.m
+++ b/Sources/CyclopMediaHelper/helper.m
@@ -21,13 +21,14 @@ typedef void (*MRGetInfoFn)(dispatch_queue_t, void (^)(CFDictionaryRef));
 typedef void (*MRGetBoolFn)(dispatch_queue_t, void (^)(Boolean));
 typedef void (*MRRegisterFn)(dispatch_queue_t);
 typedef Boolean (*MRSendCommandFn)(int, CFDictionaryRef);
-typedef void (*MRSetElapsedFn)(double);
 typedef void (*MRGetPIDFn)(dispatch_queue_t, void (^)(int));
+
+/// kMRMediaRemoteCommandSeekToPlaybackPosition.
+static const int kSeekCommand = 45;
 
 static MRGetInfoFn sGetInfo;
 static MRGetBoolFn sGetIsPlaying;
 static MRSendCommandFn sSendCommand;
-static MRSetElapsedFn sSetElapsed;
 static MRGetPIDFn sGetPID;
 static int sOwnerPID;
 static dispatch_queue_t sQueue;
@@ -70,10 +71,17 @@ static void publish(void) {
             out[@"rate"] = info[@"kMRMediaRemoteNowPlayingInfoPlaybackRate"] ?: @0;
             out[@"pid"] = @(sOwnerPID);
 
-            id stamp = info[@"kMRMediaRemoteNowPlayingInfoTimestamp"];
-            out[@"timestamp"] = [stamp isKindOfClass:NSDate.class]
-                ? @([(NSDate *)stamp timeIntervalSince1970])
-                : @0;
+            // Elapsed time is a reading taken at Timestamp, not a live clock:
+            // the daemon stores what the player last told it and never advances
+            // it. A track can play for minutes with elapsed frozen at 0. Both
+            // halves have to travel together or the number means nothing — the
+            // reader turns them back into a position by counting forward from
+            // the stamp. `now` is sent with them so that counting starts from
+            // the moment the record was read rather than the moment the line
+            // was parsed, and so a reader can tell how stale its copy is.
+            NSDate *stamp = info[@"kMRMediaRemoteNowPlayingInfoTimestamp"];
+            if ([stamp isKindOfClass:NSDate.class]) out[@"timestamp"] = @(stamp.timeIntervalSince1970);
+            out[@"now"] = @(NSDate.date.timeIntervalSince1970);
 
             NSString *artworkID = info[@"kMRMediaRemoteNowPlayingInfoArtworkIdentifier"] ?: title;
             NSData *artwork = info[@"kMRMediaRemoteNowPlayingInfoArtworkData"];
@@ -88,15 +96,36 @@ static void publish(void) {
     });
 }
 
+/// Reads the record a moment from now. Publishing in the same breath as a
+/// command only ever reports the state the command was meant to change, since
+/// nothing downstream has acted on it yet.
+static void publishSoon(void) {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.35 * NSEC_PER_SEC)), sQueue, ^{
+        publish();
+    });
+}
+
 static void handleCommand(NSString *line) {
     if ([line isEqualToString:@"get"]) {
         publish();
     } else if ([line hasPrefix:@"cmd "]) {
         if (sSendCommand) sSendCommand([line substringFromIndex:4].intValue, NULL);
-        publish();
+        publishSoon();
     } else if ([line hasPrefix:@"seek "]) {
-        if (sSetElapsed) sSetElapsed([line substringFromIndex:5].doubleValue);
-        publish();
+        // Deliberately not MRMediaRemoteSetElapsedTime. That call writes a
+        // position into the daemon's own record without asking the player to
+        // move; the bar jumps, the music carries on where it was, and every
+        // later reading is offset by the difference until the track changes.
+        // Measured on macOS 26.5.2: one call left the record 29.6 s adrift of
+        // Spotify for the rest of the song. The seek command at least asks the
+        // player, which is the only thing that can actually move the playhead.
+        if (sSendCommand) {
+            double position = [line substringFromIndex:5].doubleValue;
+            sSendCommand(kSeekCommand, (__bridge CFDictionaryRef)@{
+                @"kMRMediaRemoteOptionPlaybackPosition": @(position)
+            });
+        }
+        publishSoon();
     }
 }
 
@@ -112,7 +141,6 @@ static void startFeed(void) {
         sGetInfo = (MRGetInfoFn)dlsym(handle, "MRMediaRemoteGetNowPlayingInfo");
         sGetIsPlaying = (MRGetBoolFn)dlsym(handle, "MRMediaRemoteGetNowPlayingApplicationIsPlaying");
         sSendCommand = (MRSendCommandFn)dlsym(handle, "MRMediaRemoteSendCommand");
-        sSetElapsed = (MRSetElapsedFn)dlsym(handle, "MRMediaRemoteSetElapsedTime");
         sGetPID = (MRGetPIDFn)dlsym(handle, "MRMediaRemoteGetNowPlayingApplicationPID");
 
         MRRegisterFn registerNotifications =
@@ -124,6 +152,10 @@ static void startFeed(void) {
             @"kMRMediaRemoteNowPlayingApplicationIsPlayingDidChangeNotification",
             @"kMRMediaRemoteNowPlayingApplicationDidChangeNotification",
         ];
+        // Kept because they cost nothing and do fire on some systems — but they
+        // cannot be relied on. On macOS 26.5.2 not one of these arrived across
+        // repeated half-minute windows that contained real track changes, so
+        // `NowPlayingFeed` polls with `get` rather than waiting to be told.
         for (NSString *name in names) {
             [NSNotificationCenter.defaultCenter addObserverForName:name
                                                            object:nil


### PR DESCRIPTION
**Проблема**

На macOS 26.5.2 (25F84) виджет медиа регулярно расходится с плеером: позиция замирает или прыгает назад, перемотка не доезжает, смена трека не отражается. Причины измерены пробниками в том же perl-хосте, что использует хелпер:

- MRMediaRemoteSetElapsedTime не двигает плеер, а лишь переписывает запись демона — после одного вызова запись стояла в 29.6 с от реальной позиции Spotify до конца трека;
- MRMediaRemoteSendCommand возвращает успех и не доставляет ничего (play/pause не срабатывает, seek не перематывает);
- уведомления kMRMediaRemote…DidChange не приходят вообще — ноль за 30-секундные окна со сменами треков;
- запись сессии может быть пустой при играющем плеере или отставать на целый трек;
- set st to … в AppleScript перестал компилироваться — st стал зарезервированным токеном, из-за чего скриптовый фолбэк был мёртв целиком.

**Что сделано (по коммиту на блок)**

1. Fix Now Playing sync — хелпер отдаёт таймстамп записи + момент чтения, фид экстраполирует живую позицию (livePosition); seek через команду SeekToPlaybackPosition вместо порчи записи.
2. Player connectors — протокол PlayerConnector (Spotify, Music): когда сессией владеет скриптуемый плеер, он авторитет по состоянию, транспорту и обложке; опрос раз в секунду при открытой панели вместо мёртвых уведомлений; заморозка бара при буферизации; обложки: таймауты 6 с, oEmbed-фолбэк (в т.ч. когда основной CDN заблокирован сетью — случается), session-кэш, плейсхолдер для локальных файлов Spotify, у которых обложки нет ни в одном доступном источнике.
3. Media pane — громкость (по наведению на динамик), shuffle/repeat по возможностям плеера, «осталось до конца» кликом по таймеру, клик по обложке поднимает приложение-владельца.

Хелпер остаётся единственным источником для сессий без коннектора (вкладки браузера). Санитизация метаданных и лимиты из #1 сохранены; https-only проверка перенесена в единственную точку сетевых запросов и закрывает также oEmbed-путь.

**Проверка**

Каждый коммит собирается автономно (swift build + clang хелпера). Вручную прогнано на macOS 26.5.2 со Spotify: перемотка в обе стороны, смена треков, пауза из плеера, буферизация, локальные файлы, резерв CDN обложек.