### PR TITLE
Полка: копия карточки уходит одним элементом, а не двумя

### DIFF
--- a/Sources/Cyclop/Services/ShelfStore.swift
+++ b/Sources/Cyclop/Services/ShelfStore.swift
@@ -128,10 +128,16 @@ final class ShelfStore: ObservableObject {
     func copy(_ item: ShelfItem) {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
+        // The file goes on first and everything below is added to the item it
+        // creates. Order is the whole of it: `setData` always writes to the
+        // first item, `writeObjects` appends a new one — so marking first put
+        // the picture on one item and the file on another. One card then
+        // arrives as two objects, and an editor that accepts both pastes the
+        // screenshot twice.
+        pasteboard.writeObjects([item.url as NSURL])
         // Tells ClipboardStore this change came from us, so a copied screenshot
         // is not saved to disk a second time.
         pasteboard.setData(Data(), forType: .cyclopInternal)
-        pasteboard.writeObjects([item.url as NSURL])
         if let type = UTType(filenameExtension: item.url.pathExtension),
            type.conforms(to: .image),
            let data = try? Data(contentsOf: item.url) {


### PR DESCRIPTION
**Проблема**

`ShelfStore.copy(_:)` обещает в комментарии одну запись, у которой есть и картинка,
и файл: «Images go as image data as well as a file reference, so pasting works both
in Finder and in an editor». В буфер уезжает не это.

`setData(_:forType:)` всегда пишет в **первый** элемент пастборда, а `writeObjects(_:)`
**добавляет новый**. Маркер `.cyclopInternal` ставился первым — значит первый элемент
создавал он, файл уходил во второй, а байты картинки возвращались в первый:

```
item[0]  ["com.cyclop.internal", "public.png"]
item[1]  ["public.file-url"]
```

Одна карточка лежит в буфере как два объекта. Приложение, которое принимает и
картинки, и файлы, получает оба и вставляет скриншот дважды — один раз картинкой,
второй раз файлом.

**Правка**

Порядок вызовов — вся правка. Файл кладётся первым, маркер и байты картинки
добавляются к элементу, который он создал. Ни одной новой строки логики.

**Замер**

macOS 26.5.2 (25F84), Swift 6.3.2. Пастборд собирается ровно теми же вызовами, что
и в `copy(_:)`, и читается так, как его читает потребитель:

|                                | было | стало |
|--------------------------------|------|-------|
| элементов на пастборде         | 2    | **1** |
| `readObjects([NSImage, NSURL])` | 2   | **1** |
| file URL читается              | да   | да    |
| байты картинки читаются        | да   | да    |
| маркер виден `ClipboardStore`  | да   | да    |
| legacy `NSFilenamesPboardType` | да   | да    |

Важны обе половины таблицы: верхняя — то, что чинится, нижняя — то, что не должно
было сломаться. Маркер обязан остаться видимым, иначе `ClipboardStore.poll()`
(`Sources/Cyclop/Services/ClipboardStore.swift:116`) примет нашу же запись за чужую
и сохранит скриншот на диск второй раз. Файловые флейворы обязаны остаться, иначе
перестанет работать вставка в Finder.

**Почему не собранный вручную `NSPasteboardItem`**

Пробовал и так: один элемент, в него `setString(url.absoluteString, forType: .fileURL)`
и остальное. Результат по таблице тот же, включая legacy-флейворы, — но это больше
кода и своя копия того, что `writeObjects` уже умеет. Те же три вызова в правильном
порядке дают ровно этот результат, поэтому оставил перестановку.

**Проверено**

`swift build` и `./Scripts/bundle.sh release` проходят, `codesign --verify --strict`
на собранном бандле чистый, проверка ключей перевода из CI — без пропусков
(новых строк правка не добавляет).
