### PR TITLE
Тело панели считается от рельса, а не от числа 208

### DIFF
--- a/Sources/Cyclop/Model/NotchViewModel.swift
+++ b/Sources/Cyclop/Model/NotchViewModel.swift
@@ -36,9 +36,11 @@ final class NotchViewModel: ObservableObject {
         var needsKeyboard: Bool { self == .translate || self == .snippets || self == .notes }
 
         /// Which rail the icon sits on. The left one carries the original six
-        /// and is full — a seventh icon would outgrow the height the panel
-        /// body has — so growth continues in a second column on the right,
-        /// which the scratch notes open.
+        /// and is full — the body is measured from this list now (#26), so a
+        /// seventh icon no longer overflows the panel, it makes the panel
+        /// taller, which is the same objection worded politely. Growth
+        /// continues in a second column on the right, which the scratch notes
+        /// open.
         static let leftRail: [Tab] = [.media, .shelf, .clipboard, .snippets, .calendar, .translate]
         static let rightRail: [Tab] = [.notes]
     }

--- a/Sources/Cyclop/Model/NotchViewModel.swift
+++ b/Sources/Cyclop/Model/NotchViewModel.swift
@@ -36,11 +36,11 @@ final class NotchViewModel: ObservableObject {
         var needsKeyboard: Bool { self == .translate || self == .snippets || self == .notes }
 
         /// Which rail the icon sits on. The left one carries the original six
-        /// and is full — the body is measured from this list now (#26), so a
-        /// seventh icon no longer overflows the panel, it makes the panel
-        /// taller, which is the same objection worded politely. Growth
-        /// continues in a second column on the right, which the scratch notes
-        /// open.
+        /// and is full — icon height is a ceiling now, not a constant (#26,
+        /// #27), so a seventh icon would not overflow the panel, but it would
+        /// shrink every icon on the rail to make room, which is the same
+        /// objection in a quieter voice. Growth continues in a second column
+        /// on the right, which the scratch notes open.
         static let leftRail: [Tab] = [.media, .shelf, .clipboard, .snippets, .calendar, .translate]
         static let rightRail: [Tab] = [.notes]
     }

--- a/Sources/Cyclop/Notch/NotchGeometry.swift
+++ b/Sources/Cyclop/Notch/NotchGeometry.swift
@@ -11,8 +11,40 @@ struct NotchGeometry {
     /// True when the display actually has a notch cut into it.
     let isPhysical: Bool
 
+    /// Metrics of the tab rail, kept here rather than with the view because the
+    /// body's height is measured from them: the rail is the tallest thing in the
+    /// panel and the only thing in it that cannot give way.
+    static let railIconHeight: CGFloat = 24
+    static let railSpacing: CGFloat = 4
+    /// Gap between the rail and the bottom edge of the body.
+    static let bodyBottomPadding: CGFloat = 14
+
+    /// Height the body owes whatever stands in it.
+    ///
+    /// Read from the rail that is actually there, not written down: a rail that
+    /// grows an icon takes the body with it, instead of quietly outgrowing it
+    /// the way six icons already have.
+    static var contentHeight: CGFloat {
+        let icons = CGFloat(NotchViewModel.Tab.leftRail.count)
+        return icons * railIconHeight + (icons - 1) * railSpacing + bodyBottomPadding
+    }
+
     /// Size of the fully expanded panel body.
-    let expandedSize = CGSize(width: 620, height: 208)
+    ///
+    /// The height follows the header instead of standing still. Holding the
+    /// outside constant at 208 is what left the rail short: the header is the
+    /// notch's own height, and a real notch is taller than a menu bar — 38
+    /// against 30 on a 13" M1 — so on a Mac with a cutout those points came out
+    /// of the content. The rail asks for 164 and was handed 156, which put its
+    /// bottom icon 8 pt into the padding beneath it (#26).
+    ///
+    /// So the constant is the inside now. Every Mac gets the same body, and the
+    /// panel differs on the outside by exactly the notch it hangs from — which
+    /// is the one thing that genuinely differs between them.
+    var expandedSize: CGSize {
+        CGSize(width: 620, height: notchSize.height + Self.contentHeight)
+    }
+
     /// Slack around the panel so the concave shoulders and shadow are not clipped.
     let windowPadding = NSEdgeInsets(top: 0, left: 40, bottom: 44, right: 40)
 

--- a/Sources/Cyclop/Notch/NotchGeometry.swift
+++ b/Sources/Cyclop/Notch/NotchGeometry.swift
@@ -11,38 +11,34 @@ struct NotchGeometry {
     /// True when the display actually has a notch cut into it.
     let isPhysical: Bool
 
-    /// Metrics of the tab rail, kept here rather than with the view because the
-    /// body's height is measured from them: the rail is the tallest thing in the
-    /// panel and the only thing in it that cannot give way.
-    static let railIconHeight: CGFloat = 24
+    /// Metrics of the tab rail that do not depend on the notch. `railIconHeight`
+    /// is not among them — see below.
     static let railSpacing: CGFloat = 4
     /// Gap between the rail and the bottom edge of the body.
     static let bodyBottomPadding: CGFloat = 14
 
-    /// Height the body owes whatever stands in it.
-    ///
-    /// Read from the rail that is actually there, not written down: a rail that
-    /// grows an icon takes the body with it, instead of quietly outgrowing it
-    /// the way six icons already have.
-    static var contentHeight: CGFloat {
-        let icons = CGFloat(NotchViewModel.Tab.leftRail.count)
-        return icons * railIconHeight + (icons - 1) * railSpacing + bodyBottomPadding
-    }
+    /// Size of the fully expanded panel body. Held constant across every Mac:
+    /// letting it follow the header made two people on the very same model
+    /// see two different heights, just from different display-scaling
+    /// settings — 38 pt against 32 for the same physical notch, an 11 pt
+    /// spread from one slider (#27). What differs between Macs lives in
+    /// `railIconHeight` instead, which is the one thing in the body actually
+    /// free to give.
+    let expandedSize = CGSize(width: 620, height: 208)
 
-    /// Size of the fully expanded panel body.
-    ///
-    /// The height follows the header instead of standing still. Holding the
-    /// outside constant at 208 is what left the rail short: the header is the
-    /// notch's own height, and a real notch is taller than a menu bar — 38
-    /// against 30 on a 13" M1 — so on a Mac with a cutout those points came out
-    /// of the content. The rail asks for 164 and was handed 156, which put its
-    /// bottom icon 8 pt into the padding beneath it (#26).
-    ///
-    /// So the constant is the inside now. Every Mac gets the same body, and the
-    /// panel differs on the outside by exactly the notch it hangs from — which
-    /// is the one thing that genuinely differs between them.
-    var expandedSize: CGSize {
-        CGSize(width: 620, height: notchSize.height + Self.contentHeight)
+    /// Height each rail icon gets. A ceiling, not a constant: six icons at
+    /// the full 24 pt plus the five 4 pt gaps between them is 164 pt, and
+    /// the body only has `expandedSize.height − notchSize.height −
+    /// bodyBottomPadding` left to give the rail once the header — the notch
+    /// itself — and the padding beneath are taken out of the fixed 208.
+    /// Rounded down rather than to the nearest point: a rail that asks for
+    /// more than it is given should visibly yield, not overflow by a
+    /// fraction that clips it.
+    var railIconHeight: CGFloat {
+        let icons = CGFloat(NotchViewModel.Tab.leftRail.count)
+        let available = expandedSize.height - notchSize.height - Self.bodyBottomPadding
+        let ceiling = (available - (icons - 1) * Self.railSpacing) / icons
+        return min(24, ceiling).rounded(.down)
     }
 
     /// Slack around the panel so the concave shoulders and shadow are not clipped.

--- a/Sources/Cyclop/UI/NotchContentView.swift
+++ b/Sources/Cyclop/UI/NotchContentView.swift
@@ -205,7 +205,7 @@ private struct Rail: View {
                 } label: {
                     Image(systemName: tab.symbol)
                         .font(.system(size: 12, weight: .medium))
-                        .frame(width: 30, height: NotchGeometry.railIconHeight)
+                        .frame(width: 30, height: vm.geometry.railIconHeight)
                         .background(
                             RoundedRectangle(cornerRadius: 7, style: .continuous)
                                 .fill(fill(for: tab))

--- a/Sources/Cyclop/UI/NotchContentView.swift
+++ b/Sources/Cyclop/UI/NotchContentView.swift
@@ -117,7 +117,9 @@ struct NotchContentView: View {
             Rail(vm: vm, tabs: NotchViewModel.Tab.rightRail)
         }
         .padding(.horizontal, 14)
-        .padding(.bottom, 14)
+        // The body's height is measured from this same number, so the two
+        // cannot drift apart into a rail that does not fit.
+        .padding(.bottom, NotchGeometry.bodyBottomPadding)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
@@ -196,14 +198,14 @@ private struct Rail: View {
     private let dwell = Duration.milliseconds(150)
 
     var body: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: NotchGeometry.railSpacing) {
             ForEach(tabs) { tab in
                 Button {
                     vm.select(tab)
                 } label: {
                     Image(systemName: tab.symbol)
                         .font(.system(size: 12, weight: .medium))
-                        .frame(width: 30, height: 24)
+                        .frame(width: 30, height: NotchGeometry.railIconHeight)
                         .background(
                             RoundedRectangle(cornerRadius: 7, style: .continuous)
                                 .fill(fill(for: tab))


### PR DESCRIPTION
Чинит #26.

Это **вариант А** из тех двух, что я там назвал — растить тело под вырез. Если
ближе второй (ужимать рельс), скажите, переделаю: правка небольшая в любую сторону.

**Причина**

Высота тела была константой (208), а шапка — переменной: её высота равна высоте
чёлки (`Sources/Cyclop/UI/NotchContentView.swift:66`). У физического выреза это
38, у синтетической чёлки — 30, и вся разница вычиталась из содержимого. Рельсу
нужно 164 — шесть иконок по 24 и пять зазоров по 4 — а доставалось ему
`208 − 38 − 14 = 156`.

**Правка**

Константа теперь внутренность, а не наружность: тело равно шапке плюс то, что
просит рельс. Каждый мак получает одинаковое содержимое, а панели различаются
снаружи ровно на ту чёлку, под которой висят, — то есть на единственное, чем эти
маки и правда отличаются.

Число 164 при этом нигде не записано: `contentHeight` спрашивает его у самого
рельса через `Tab.leftRail.count`. Рельс, которому добавят иконку, потянет тело
за собой, вместо того чтобы молча перерасти его — как уже переросли шесть.
Поэтому же три метрики (высота иконки, зазор, нижний отступ) переехали в
`NotchGeometry` и используются и видом, и геометрией: разъехаться им теперь
негде.

Заодно поправлен комментарий про «седьмая иконка не влезет» в
`Sources/Cyclop/Model/NotchViewModel.swift:38` — он описывал ограничение,
которого больше нет. Сам состав рельсов не тронут: второй столбец остаётся, но
уже потому, что панель не должна расти бесконечно, а не потому, что содержимое
переполнится.

**Замер**

MacBook Air M4 (Mac16,12), macOS 26.5.2 (25F84), встроенный вырез 38 pt.
Рамка снята `GeometryReader` на живой панели:

| | было | стало |
|---|---|---|
| высота тела | 208 | **216** |
| рамка рельса | `{{54, 38}, {30, 164}}` | `{{54, 38}, {30, 164}}` |
| зазор под рельсом | **6** | **14** |

Рельс не сдвинулся — подросло тело под ним, и нижний отступ стал тем, каким
задуман.

**Что с маками без выреза**

Ничего. Шапка там 30, `30 + 178 = 208` — прежняя высота до точки. Арифметика не
изменилась, просто там она всегда сходилась. На машинах, где меню-бар ниже 30
(нижняя граница в `NotchGeometry` — 24), тело станет на столько же ниже, а
содержимое останется тем же: пустое место под рельсом больше не носим. Это
единственное поведенческое изменение вне маков с вырезом, и оно в ту же сторону.

**Проверено**

`swift build`, `./Scripts/bundle.sh release`, `codesign --verify --strict` на
собранном бандле, проверка ключей перевода из CI — чисто. Новых строк правка не
добавляет. Панель прогнана вживую: раскрытие, все шесть переходов по рельсу в обе
стороны, свёртывание.
