### PR TITLE
Обложка не своей формы перестала накрывать рельс (#22)

### DIFF
--- a/Sources/Cyclop/UI/MediaPane.swift
+++ b/Sources/Cyclop/UI/MediaPane.swift
@@ -65,6 +65,14 @@ struct MediaPane: View {
         }
         .frame(width: 118, height: 118)
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        // The same shape again, this time for the pointer. `clipShape` hides
+        // the overflow but does not stop it being touched, and `.fill` on a
+        // cover that is not square overflows a long way: a 16:9 thumbnail —
+        // what a video in a browser tab publishes — comes out 211 pt wide in
+        // this 118 pt box, so 46 pt of invisible picture hangs over each side.
+        // The left side is the tab rail, and the four icons behind that
+        // overhang stopped answering the pointer (#22).
+        .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .strokeBorder(Theme.hairline, lineWidth: 1)


### PR DESCRIPTION
Чинит #22. Воспроизведено, локализовано до одной строки и проверено замером.

**Что происходит**

`MediaPane.artwork(for:)` рисует обложку через `.aspectRatio(contentMode: .fill)`
в коробку 118×118. `.fill` вписывает по большей стороне, поэтому неквадратная
обложка вылезает за рамку. Ролик в браузерной вкладке отдаёт превью 16:9 —
336×188 у YouTube: в коробке 118 pt оно выходит **211 pt шириной**, и по 46 pt
невидимой картинки свисает с каждой стороны.

Слева от обложки — рельс вкладок. `clipShape` прячет свес, но **не обрезает
попадание курсора**, поэтому иконки под свесом перестают отвечать: ни наведением,
ни щелчком.

**Почему ломались ровно четыре иконки из шести**

Обложка занимает по вертикали 57…175 (высота 118, центрирована в теле панели).
Иконки стоят так:

| иконка | y | под свесом |
|---|---|---|
| Музыка | 38…62 | нет (центр выше 57) |
| Полка | 66…90 | **да** |
| Буфер | 94…118 | **да** |
| Заготовки | 122…146 | **да** |
| Календарь | 150…174 | **да** |
| Перевод | 178…202 | нет (ниже 175) |

Отсюда дословно жалоба из #22 — «не переключается на другие разделы **кроме
Переводчика**»: он последний в столбце и единственный свободный снизу.

И отсюда же «снизу вверх работает, сверху вниз нет». Сверху вниз курсор упирается
в мёртвую зону и доходит только до «Перевода». А как только «Перевод» выбран,
вкладка сменилась, `MediaPane` ушёл с экрана вместе с обложкой — и обратный путь
проходит уже по живому рельсу. Направление тут ни при чём, важно лишь то, какая
вкладка показана.

**Почему это выглядело привязанным к YouTube**

У Apple Music и Spotify обложки квадратные — `.fill` их не растягивает, свеса нет,
рельс цел. Неквадратное превью отдают именно видео в браузере. На маке, где
проверяли под Apple Music, баг не воспроизводится никогда.

**Правка**

Одна строка: та же форма объявляется ещё раз, теперь для курсора.

**Замер**

MacBook Air M4 (Mac16,12), macOS 26.5.2 (25F84), встроенный вырез. Жест —
от чёлки вниз по всем шести иконкам с задержкой на каждой, затем обратно вверх;
события мыши настоящие (`CGEvent`), с дрожанием по обеим осям. Считаются
состоявшиеся переключения из десяти возможных:

| обложка | было | стало |
|---|---|---|
| 336×188 (16:9, как у YouTube) | **6/10** | **10/10** |
| 200×200 (квадрат) | 10/10 | 10/10 |
| 188×336 (портрет) | 10/10 | 10/10 |
| нет обложки | 10/10 | 10/10 |

Живьём, до правки: YouTube в Safari, обложка 336×188 — **6/10, три прогона из
трёх, посимвольно одинаковый результат**: вниз проходит только «Перевод», вверх
проходит всё.

Что при этом было исключено отдельными прогонами и к делу не относится: тикер
позиции 4 Гц, `repeatForever` у эквалайзера, размер обложки (6000×6000 не мешает,
если она квадратная), длина имени источника, полная загрузка процессора,
скорость наведения от 120 до 1100 мс.

**Альтернатива**

Можно было не объявлять форму, а снять с обложки интерактивность целиком —
`.allowsHitTesting(false)`; проверял, тоже даёт 10/10. Оставил `contentShape`,
потому что он чинит настоящую причину — область попадания разошлась с видимой, —
и не закрывает дорогу нажатию на обложку, если оно когда-нибудь понадобится.
Скажите, если предпочтёте второй вариант.

**Проверено**

`swift build`, `./Scripts/bundle.sh release`, `codesign --verify --strict`,
проверка ключей перевода из CI. Новых строк правка не добавляет.
