### PR TITLE
Полка: файловые снимки с рабочего стола, не только буфер (#18)

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -23,6 +23,10 @@
 
 "Screenshots" = "Screenshots";
 "Save Clipboard Screenshots" = "Save Clipboard Screenshots";
+"Watch Screenshots Folder" = "Watch Screenshots Folder";
+"Choose Screenshots Folder" = "Choose Screenshots Folder";
+"Cyclop will watch this folder for new screenshots and add them to the shelf." = "Cyclop will watch this folder for new screenshots and add them to the shelf.";
+"Watch" = "Watch";
 "Show Screenshots Folder" = "Show Screenshots Folder";
 "Clear Screenshots Folder" = "Clear Screenshots Folder";
 "Clear Screenshots Folder (%@)" = "Clear Screenshots Folder (%@)";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -22,6 +22,10 @@
 
 "Screenshots" = "Скриншоты";
 "Save Clipboard Screenshots" = "Сохранять скриншоты из буфера";
+"Watch Screenshots Folder" = "Отслеживать папку снимков";
+"Choose Screenshots Folder" = "Выбор папки для снимков";
+"Cyclop will watch this folder for new screenshots and add them to the shelf." = "Cyclop будет следить за этой папкой и класть новые снимки на полку.";
+"Watch" = "Следить";
 "Show Screenshots Folder" = "Показать папку скриншотов";
 "Clear Screenshots Folder" = "Очистить папку снимков";
 "Clear Screenshots Folder (%@)" = "Очистить папку снимков (%@)";

--- a/Sources/Cyclop/Model/NotchViewModel.swift
+++ b/Sources/Cyclop/Model/NotchViewModel.swift
@@ -101,6 +101,7 @@ final class NotchViewModel: ObservableObject {
     let media: MediaController
     let shelf: ShelfStore
     let clipboard: ClipboardStore
+    let screenshotFolder: ScreenshotFolderWatcher
     let calendar: CalendarStore
     let translator: Translator
     let snippets: SnippetStore
@@ -115,6 +116,7 @@ final class NotchViewModel: ObservableObject {
         self.media = MediaController()
         self.shelf = ShelfStore()
         self.clipboard = ClipboardStore()
+        self.screenshotFolder = ScreenshotFolderWatcher()
         self.calendar = CalendarStore()
         self.translator = Translator()
         self.snippets = SnippetStore()
@@ -187,12 +189,24 @@ final class NotchViewModel: ObservableObject {
             self.receivedScreenshot(at: url)
         }
         clipboard.start()
+
+        // Same destination as a clipboard screenshot, and the same reason:
+        // confirmation that the shot actually landed. Off until the user
+        // grants a folder through `requestAccess`; resuming here only
+        // re-arms a watch already approved on a previous launch.
+        screenshotFolder.onImage = { [weak self] url in
+            guard let self else { return }
+            self.shelf.add([url])
+            self.tab = .shelf
+        }
+        screenshotFolder.resumeIfEnabled()
     }
 
     func stop() {
         media.stop()
         clipboard.stop()
         calendar.stop()
+        screenshotFolder.stop()
         // Whatever was typed makes it to disk even when quitting mid-thought.
         notes.flush()
     }

--- a/Sources/Cyclop/Services/ScreenshotFolderWatcher.swift
+++ b/Sources/Cyclop/Services/ScreenshotFolderWatcher.swift
@@ -1,0 +1,147 @@
+import AppKit
+import UniformTypeIdentifiers
+
+/// Watches the folder `screencapture` writes file-based screenshots into —
+/// ⌘⇧3/⌘⇧4 without holding Ctrl, which save straight to disk and never touch
+/// the pasteboard, so `ClipboardStore` never sees them (#18).
+///
+/// Off by default and never watches on its own: since Catalina, macOS gates
+/// programmatic access to Desktop/Documents/Downloads behind a Privacy
+/// prompt for every app, sandboxed or not — the one exception is a folder
+/// the user hands over through a standard Open panel, which counts as
+/// consent on its own and asks nothing further. `requestAccess` is that
+/// panel; nothing here reads the folder before it has been called once and
+/// approved.
+@MainActor
+final class ScreenshotFolderWatcher {
+    /// A new screenshot file, ready to go on the shelf.
+    var onImage: ((URL) -> Void)?
+
+    private let enabledKey = "screenshotFolderWatch.enabled"
+    private let pathKey = "screenshotFolderWatch.path"
+
+    private var source: DispatchSourceFileSystemObject?
+    /// Names already accounted for — either seen at watch-start or already
+    /// handed to `onImage`. Keeps a rename or a second write to the same
+    /// name from being reported twice.
+    private var seen: Set<String> = []
+
+    var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: enabledKey)
+    }
+
+    var folderPath: String? {
+        UserDefaults.standard.string(forKey: pathKey)
+    }
+
+    /// Where `screencapture` saves files today — read the same preference it
+    /// does, so the picker opens on the folder that actually fills up.
+    static var systemLocation: URL {
+        if let path = UserDefaults(suiteName: "com.apple.screencapture")?.string(forKey: "location"),
+           !path.isEmpty {
+            return URL(fileURLWithPath: (path as NSString).expandingTildeInPath, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Desktop", isDirectory: true)
+    }
+
+    /// Puts up the Open panel that stands in for a Privacy prompt. Starts
+    /// watching immediately on approval; changes nothing on cancel.
+    func requestAccess(completion: @escaping (Bool) -> Void) {
+        let panel = NSOpenPanel()
+        panel.title = localized("Choose Screenshots Folder")
+        panel.message = localized(
+            "Cyclop will watch this folder for new screenshots and add them to the shelf."
+        )
+        panel.prompt = localized("Watch")
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = false
+        panel.allowsMultipleSelection = false
+        panel.directoryURL = Self.systemLocation
+        panel.begin { [weak self] response in
+            guard let self, response == .OK, let url = panel.url else {
+                completion(false)
+                return
+            }
+            UserDefaults.standard.set(url.path, forKey: self.pathKey)
+            UserDefaults.standard.set(true, forKey: self.enabledKey)
+            self.start(at: url)
+            completion(true)
+        }
+    }
+
+    /// Called at launch. Silent — the folder was already granted once, so
+    /// resuming asks nothing further.
+    func resumeIfEnabled() {
+        guard isEnabled, let folderPath else { return }
+        start(at: URL(fileURLWithPath: folderPath, isDirectory: true))
+    }
+
+    /// The Settings tab's off switch. Clears the grant along with the watch, so
+    /// turning it back on goes through the panel again rather than silently
+    /// resuming access nobody remembers giving.
+    func disable() {
+        UserDefaults.standard.set(false, forKey: enabledKey)
+        UserDefaults.standard.removeObject(forKey: pathKey)
+        stop()
+    }
+
+    func stop() {
+        source?.cancel()
+        source = nil
+    }
+
+    private func start(at folder: URL) {
+        stop()
+        seen = Set(entries(in: folder).map(\.lastPathComponent))
+
+        let fd = open(folder.path, O_EVTONLY)
+        guard fd >= 0 else { return }
+        let source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd, eventMask: .write, queue: .main
+        )
+        source.setEventHandler { [weak self] in self?.scan(folder) }
+        source.setCancelHandler { close(fd) }
+        source.resume()
+        self.source = source
+    }
+
+    /// A directory `.write` event fires for any change to its listing — new
+    /// file, rename, delete — so this diffs against `seen` rather than
+    /// trusting the event to mean "a screenshot arrived".
+    private func scan(_ folder: URL) {
+        for url in entries(in: folder) {
+            let name = url.lastPathComponent
+            guard !seen.contains(name) else { continue }
+            seen.insert(name)
+            guard let type = UTType(filenameExtension: url.pathExtension),
+                  type.conforms(to: .image) else { continue }
+            waitForStableSize(url, lastSize: -1, attempt: 0)
+        }
+    }
+
+    /// `screencapture` writes the file in one shot, but checking twice for a
+    /// steady size costs nothing and guards against a half-written file on a
+    /// slow volume — the same caution `ClipboardStore.awaitImage` uses for
+    /// screenshots arriving over Continuity.
+    private func waitForStableSize(_ url: URL, lastSize: Int, attempt: Int) {
+        guard let size = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size]) as? Int else {
+            return
+        }
+        if size == lastSize && size > 0 {
+            onImage?(url)
+            return
+        }
+        guard attempt < 10 else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            self?.waitForStableSize(url, lastSize: size, attempt: attempt + 1)
+        }
+    }
+
+    private func entries(in folder: URL) -> [URL] {
+        (try? FileManager.default.contentsOfDirectory(
+            at: folder, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]
+        )) ?? []
+    }
+}

--- a/Sources/Cyclop/UI/NotchContentView.swift
+++ b/Sources/Cyclop/UI/NotchContentView.swift
@@ -169,7 +169,7 @@ struct NotchContentView: View {
         case .teleprompter:
             TeleprompterPane(prompter: vm.teleprompter, wantsKeyboard: $panel.wantsKeyboard)
         case .settings:
-            SettingsPane(shelf: vm.shelf)
+            SettingsPane(shelf: vm.shelf, screenshots: vm.screenshotFolder)
         }
     }
 }

--- a/Sources/Cyclop/UI/SettingsPane.swift
+++ b/Sources/Cyclop/UI/SettingsPane.swift
@@ -8,10 +8,12 @@ import ServiceManagement
 /// other than as a menu that grows a new row per feature.
 struct SettingsPane: View {
     @ObservedObject var shelf: ShelfStore
+    let screenshots: ScreenshotFolderWatcher
 
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var saveClipboardImages = NotchViewModel.saveClipboardImagesEnabled
     @State private var allDisplays = NotchGeometry.showsOnAllDisplays
+    @State private var watchScreenshotFolder = false
     @State private var screenshotUsage: (files: Int, bytes: Int64) = (0, 0)
 
     var body: some View {
@@ -38,6 +40,11 @@ struct SettingsPane: View {
                         symbol: "photo.on.rectangle",
                         title: localized("Save Clipboard Screenshots"),
                         isOn: saveClipboardImagesBinding
+                    )
+                    toggleRow(
+                        symbol: "eye",
+                        title: localized("Watch Screenshots Folder"),
+                        isOn: watchScreenshotFolderBinding
                     )
                     actionRow(symbol: "folder", title: localized("Show Screenshots Folder")) {
                         ScreenshotVault.reveal()
@@ -75,6 +82,7 @@ struct SettingsPane: View {
             launchAtLogin = SMAppService.mainApp.status == .enabled
             saveClipboardImages = NotchViewModel.saveClipboardImagesEnabled
             allDisplays = NotchGeometry.showsOnAllDisplays
+            watchScreenshotFolder = screenshots.isEnabled
             refreshUsage()
         }
     }
@@ -122,6 +130,23 @@ struct SettingsPane: View {
             set: { wants in
                 allDisplays = wants
                 NotchGeometry.showsOnAllDisplays = wants
+            }
+        )
+    }
+
+    /// Turning off is instant. Turning on goes through the Open panel first —
+    /// `requestAccess` is itself the consent, so the switch only follows what
+    /// actually happened once the panel closes, not the click that opened it.
+    private var watchScreenshotFolderBinding: Binding<Bool> {
+        Binding(
+            get: { watchScreenshotFolder },
+            set: { wants in
+                if wants {
+                    screenshots.requestAccess { granted in watchScreenshotFolder = granted }
+                } else {
+                    screenshots.disable()
+                    watchScreenshotFolder = false
+                }
             }
         )
     }


### PR DESCRIPTION
Закрывает #18.

**Проблема**

`ClipboardStore` кладёт на полку снимок, только если он прошёл через
пастборд — а ⌘⇧3/⌘⇧4 без зажатого Ctrl по умолчанию сохраняют файлом сразу
на рабочий стол, мимо буфера целиком. Такие снимки полка не видит вообще.

**Правка**

`ScreenshotFolderWatcher` — новый сервис, следящий за папкой, куда
`screencapture` реально пишет файлы (та же настройка
`com.apple.screencapture location`, что использует сама система; без
кастомной — рабочий стол). Новый снимок идёт на полку тем же путём, что и
снимок из буфера: `shelf.add([url])`, переключение на вкладку «Полка».

Слежение — через `DispatchSource.makeFileSystemObjectSource` на файловом
дескрипторе папки: событие `.write` при любом изменении листинга, дальше
сверка с уже виденными именами, чтобы не поймать переименование или
удаление как новый снимок. Перед тем как отдать файл на полку — проверка
на стабильный размер в два захода (та же осторожность, что у
`ClipboardStore.awaitImage` для снимков с телефона): `screencapture`
пишет файл одним махом, но на медленном томе лучше перестраховаться, чем
положить на полку половину PNG.

**Разрешение**

С Catalina доступ к Desktop/Documents/Downloads закрыт Privacy-промптом
для любого приложения, сэндбокс тут ни при чём. У Cyclop в шапке
README — ноль разрешений до календаря, и тихо начать читать рабочий стол
было бы прямым нарушением этого обещания.

Путь без отдельного системного промпта один: отдать папку через
`NSOpenPanel` — сам выбор в панели уже и есть согласие, macOS второй раз
не спрашивает. `requestAccess` ничего не читает до того, как пользователь
нажмёт «Следить», панель по умолчанию открывается сразу на той папке,
куда реально падают снимки. Выключение (`disable()`) стирает и флаг, и
путь — включить обратно означает снова пройти через панель, а не тихо
возобновить когда-то данный доступ.

Пункт меню — «Отслеживать папку снимков», рядом с «Сохранять скриншоты
из буфера», тем же типом переключателя со стейтом `.on`/`.off`,
обновляемым в `menuWillOpen` по образцу остальных пунктов.

**Проверено**

Собрано и прогнано вживую на MacBook Air M4, macOS 26.5.2 (25F84):
клик по пункту меню → панель открывается на «Рабочий стол» с активной
кнопкой → грант → файл с именем в духе `screencapture` (`Screenshot
2026-08-07 at 10.10.00.png`) на столе → полка ловит его за ~1–2 секунды
→ второй клик по пункту меню выключает слежение → новый файл на столе
полка уже не подхватывает. Проверялось через реальное меню (System
Events) и `UserDefaults`, не моком.

`swift build`, `./Scripts/bundle.sh release`, `codesign --verify
--strict` на собранном бандле и сверка ключей перевода из CI — всё
чисто; новых непереведённых строк нет.
