### PR TITLE
CalendarStore: не показывать события из скрытых календарей (#30)

### DIFF
--- a/Sources/Cyclop/Services/CalendarStore.swift
+++ b/Sources/Cyclop/Services/CalendarStore.swift
@@ -118,6 +118,18 @@ final class CalendarStore: ObservableObject {
         }
     }
 
+    /// Calendars unchecked in Calendar.app's sidebar. EventKit has no public
+    /// notion of this at all — "shown or not" is Calendar.app's own UI state,
+    /// not calendar data, so it lives in Calendar.app's preferences instead.
+    /// The identifiers there are the same ones EventKit hands out: Calendar.app
+    /// and EventKit both read the same underlying calendar store.
+    private static func hiddenCalendarIdentifiers() -> Set<String> {
+        guard let disabled = CFPreferencesCopyAppValue(
+            "DisabledCalendars" as CFString, "com.apple.iCal" as CFString
+        ) as? [String: [String]] else { return [] }
+        return Set(disabled.values.flatMap { $0 })
+    }
+
     private func observe() {
         guard observer == nil else { return }
         observer = NotificationCenter.default.addObserver(
@@ -156,11 +168,13 @@ final class CalendarStore: ObservableObject {
 
     func reload() {
         guard access == .granted else { return }
+        let hidden = Self.hiddenCalendarIdentifiers()
+        let calendars = store.calendars(for: .event).filter { !hidden.contains($0.calendarIdentifier) }
         let start = Date()
         let predicate = store.predicateForEvents(
             withStart: start,
             end: start.addingTimeInterval(horizon),
-            calendars: nil
+            calendars: calendars
         )
         meetings = store.events(matching: predicate)
             .filter { !$0.isAllDay && $0.status != .canceled }


### PR DESCRIPTION
Закрывает половину #30 (вторая половина — кнопка Join у пересекающихся встреч — отдельным PR, когда определимся с UI по обсуждению в issue).

**Проблема**

`reload()` строил предикат с `calendars: nil` — то есть забирал события вообще из всех календарей, до которых у EventKit есть доступ, без разбора, включены они у пользователя в боковой панели Календаря или нет. У автора issue в Apple Calendar подключён Google-аккаунт с несколькими календарями, часть из которых скрыта (снят чекбокс) — системный Календарь их не показывает, а Cyclop показывал.

**Правка**

У `EKCalendar` в публичном EventKit нет признака «показан/скрыт» — это состояние UI самого Calendar.app, а не данные календаря, и хранится оно в его собственных настройках: домен `com.apple.iCal`, ключ `DisabledCalendars` → `{MainWindow: [UUID, ...]}`. Идентификаторы там совпадают с `EKCalendar.calendarIdentifier` — проверил вживую двумя независимыми способами: (1) `defaultCalendarID` из того же домена совпал с `calendarIdentifier` одного из реальных календарей, побитово; (2) цикл скрыть/показать тестового локального календаря через боковую панель — событие пропадало и появлялось в Cyclop ровно по этому переключению.

`hiddenCalendarIdentifiers()` читает и объединяет все массивы из `DisabledCalendars` через `CFPreferencesCopyAppValue` — обычное чтение настроек, без Full Disk Access и без нового системного промпта (в отличие от `~/Library/Calendars/`, которая под TCC). `reload()` теперь фильтрует `store.calendars(for: .event)` по этому множеству и передаёт явный список в `predicateForEvents(calendars:)` вместо `nil`.

**Проверено**

Собрано, `swift build` чисто. Вживую: локальный тестовый календарь с событием → скрыт чекбоксом в Календаре → событие пропадает из Cyclop (после возврата на вкладку) → показан обратно → событие возвращается. Полный цикл в обе стороны, не одно направление.
