### PR TITLE
CalendarPane: кнопка Join у встреч, пересекающихся с ближайшей (#30)

### DIFF
--- a/Sources/Cyclop/Services/CalendarStore.swift
+++ b/Sources/Cyclop/Services/CalendarStore.swift
@@ -27,6 +27,10 @@ final class CalendarStore: ObservableObject {
             let now = Date()
             return start <= now && now < end
         }
+
+        func overlaps(_ other: Meeting) -> Bool {
+            start < other.end && end > other.start
+        }
     }
 
     @Published private(set) var access: Access = .notRequested

--- a/Sources/Cyclop/UI/CalendarPane.swift
+++ b/Sources/Cyclop/UI/CalendarPane.swift
@@ -81,7 +81,10 @@ struct CalendarPane: View {
         .padding(.top, 4)
     }
 
-    /// Everything after the next meeting, as a column on the right.
+    /// Everything after the next meeting, as a column on the right. A meeting
+    /// that overlaps `next` in time gets its own Join button — otherwise the
+    /// only way in is switching to Calendar, and the whole point of an
+    /// overlap is that two meetings are joinable right now, not just one.
     private var rest: some View {
         VStack(alignment: .leading, spacing: 7) {
             ForEach(calendar.upcoming.prefix(4)) { meeting in
@@ -102,6 +105,10 @@ struct CalendarPane: View {
                         height: 11,
                         seed: UInt64(bitPattern: Int64(meeting.id.hashValue))
                     )
+                    if meeting.link != nil, let next = calendar.next, meeting.overlaps(next) {
+                        Spacer(minLength: 4)
+                        joinButton(for: meeting)
+                    }
                 }
             }
             if calendar.upcoming.isEmpty {
@@ -112,6 +119,23 @@ struct CalendarPane: View {
             Spacer(minLength: 0)
         }
         .frame(width: 230, alignment: .leading)
+    }
+
+    /// An icon rather than the label the main button spells out: the row has
+    /// room for a timestamp and a once-truncated title already, and "Подключиться"
+    /// wrapped onto two lines the one time it was tried at this width.
+    private func joinButton(for meeting: CalendarStore.Meeting) -> some View {
+        Button {
+            calendar.join(meeting)
+        } label: {
+            Image(systemName: "video.fill")
+                .font(.system(size: 9))
+                .foregroundStyle(.white)
+                .frame(width: 18, height: 18)
+                .background(Circle().fill(Theme.surfaceHover))
+        }
+        .buttonStyle(.plain)
+        .help(localized("Join"))
     }
 
     private func subtitle(for meeting: CalendarStore.Meeting) -> String {


### PR DESCRIPTION
Закрывает вторую половину #30. Дизайн — список с кнопкой Join у каждой пересекающейся встречи — обсудили в issue заранее, alinaermish подтвердил(а).

**Проблема**

Кнопка подключения была только у `next` — ближайшей по времени встречи. Если с ней пересекается другая (два звонка в одно время), она просто лежала в списке `upcoming` временем и заголовком, без возможности к ней перейти.

**Правка**

`Meeting.overlaps(_:)` — простое пересечение диапазонов `[start, end)`. В `rest` (правая колонка со списком) каждая встреча, которая пересекается с `next` и у которой есть ссылка, получает свою кнопку.

Первая попытка была текстовой кнопкой («Подключиться») — на такой ширине колонки она переносилась на две строки, выглядело сломанным (нашли по скриншоту). Заменил на компактную кнопку-иконку (камера в кружке) по образцу уже существующей в `NotesPane.swift` — с `.help()`-подсказкой вместо подписи.

**Проверено**

Собрано, `swift build` чисто. Вживую: локальный тестовый календарь с четырьмя событиями (два пересекаются с ближайшим, одно нет, одно без ссылки) — кнопки появились ровно у пересекающихся с ссылкой, остальные без изменений. Скриншот того же вида уже прикладывал в issue.
