### PR TITLE
NotchViewModel: снимок в буфер не отбирает клавиатуру во время набора (#25)

### DIFF
--- a/Sources/Cyclop/Model/NotchViewModel.swift
+++ b/Sources/Cyclop/Model/NotchViewModel.swift
@@ -173,8 +173,7 @@ final class NotchViewModel: ObservableObject {
         clipboard.wantsImages = { Self.saveClipboardImagesEnabled }
         clipboard.onImage = { [weak self] png in
             guard let self, let url = ScreenshotVault.save(png) else { return }
-            self.shelf.add([url])
-            self.tab = .shelf
+            self.receivedScreenshot(at: url)
         }
         clipboard.start()
     }
@@ -187,6 +186,22 @@ final class NotchViewModel: ObservableObject {
         notes.flush()
     }
 
+    /// A screenshot that arrived on its own — copied elsewhere, or synced
+    /// from a phone by Continuity — rather than one the user handed to the
+    /// panel directly. It goes on the shelf either way, but only switches to
+    /// showing it when nobody is mid-sentence: the tab's own field would
+    /// slide out from under the caret, and losing the keyboard mid-word sends
+    /// the rest of the sentence to whatever is underneath. The shelf's
+    /// counter already shows the new picture, so nothing about it is lost by
+    /// waiting.
+    func receivedScreenshot(at url: URL) {
+        shelf.add([url])
+        guard !wantsKeyboard else { return }
+        tab = .shelf
+    }
+
+    /// A file the user dropped on the panel by hand — switching to the shelf
+    /// is the point, not a side effect to guard against.
     func accept(urls: [URL]) -> Bool {
         shelf.add(urls)
         tab = .shelf


### PR DESCRIPTION
Закрывает #25.

**Проблема**

`clipboard.onImage` ставил `tab = .shelf` безусловно. `didSet` у `tab` роняет `wantsKeyboard`, если у новой вкладки нет своего поля — так снимок, попавший в буфер во время набора (⌃⌘⇧4, «Скопировать изображение» в браузере, синк с телефона по Continuity), уводил раздел на полку и отдавал клавиатуру: остаток фразы уходил в приложение под панелью, молча.

**Правка**

Как обсудили в issue: различать надо не «панель открыта/закрыта», а кто позвал событие. `accept(urls:)` (drag-and-drop) не трогаю — там файл принесли на чёлку руками, переключение верное. Новый `receivedScreenshot(at:)` кладёт картинку на полку всегда, но переключает вкладку только когда `!wantsKeyboard`.

Побочный эффект того же корня решается сам собой: `didSet` заодно вызывает `notes.leave()` при уходе с вкладки заметок — раз вкладка теперь не меняется во время набора, ещё не заполненная заметка не выметается вместе с фокусом.

**Проверено**

Собрано. Вживую: открыл вкладку с полем (Заметки), скопировал картинку в буфер через AppleScript — фокус не сбился, вкладка не переключилась, картинка появилась в списке на полке при ручном переходе туда.
