### PR TITLE
helper.m: play/pause/next/previous через per-client MediaRemote (#23)

### DIFF
--- a/Sources/Cyclop/Services/MediaController.swift
+++ b/Sources/Cyclop/Services/MediaController.swift
@@ -74,7 +74,9 @@ final class MediaController: ObservableObject {
         // Optimistic flip so the button feels instant; the feed corrects it.
         isPlaying.toggle()
         setAnchor(position)
-        dispatch(feed: .togglePlayPause, script: { PlayerBridge.playPause($0) }, key: .playPause)
+        // The per-client command set has no toggle of its own (#23) — Play
+        // and Pause are sent explicitly, by the state just flipped to above.
+        dispatch(feed: isPlaying ? .play : .pause, script: { PlayerBridge.playPause($0) }, key: .playPause)
     }
 
     func next() {

--- a/Sources/Cyclop/Services/NowPlayingFeed.swift
+++ b/Sources/Cyclop/Services/NowPlayingFeed.swift
@@ -23,8 +23,13 @@ final class NowPlayingFeed {
         var isEmpty: Bool { title.isEmpty }
     }
 
+    /// Codes the per-client MediaRemote API actually answers to — read off a
+    /// live session's `GetSupportedCommandsForPlayer`, not assumed from the
+    /// old global enum. There is no separate toggle among them: play and
+    /// pause are sent explicitly, by whichever state the caller already
+    /// knows it is in.
     enum Command: Int {
-        case play = 0, pause = 1, togglePlayPause = 2, next = 4, previous = 5
+        case play = 0, pause = 1, next = 4, previous = 5
     }
 
     var onUpdate: ((Snapshot) -> Void)?

--- a/Sources/CyclopMediaHelper/helper.m
+++ b/Sources/CyclopMediaHelper/helper.m
@@ -20,21 +20,35 @@
 typedef void (*MRGetInfoFn)(dispatch_queue_t, void (^)(CFDictionaryRef));
 typedef void (*MRGetBoolFn)(dispatch_queue_t, void (^)(Boolean));
 typedef void (*MRRegisterFn)(dispatch_queue_t);
-typedef Boolean (*MRSendCommandFn)(int, CFDictionaryRef);
-typedef void (*MRSetElapsedFn)(double);
 typedef void (*MRGetPIDFn)(dispatch_queue_t, void (^)(int));
+typedef void (*MRGetClientsFn)(dispatch_queue_t, void (^)(NSArray *));
+typedef void (*MRSendCommandToPlayerFn)(int, CFDictionaryRef, id, id, id, void (^)(id));
 
 static MRGetInfoFn sGetInfo;
 static MRGetBoolFn sGetIsPlaying;
-static MRSendCommandFn sSendCommand;
-static MRSetElapsedFn sSetElapsed;
 static MRGetPIDFn sGetPID;
+static MRGetClientsFn sGetClients;
+static MRSendCommandToPlayerFn sSendCommandToPlayer;
 static int sOwnerPID;
 static dispatch_queue_t sQueue;
 static NSString *sArtworkID;
 
 static NSString *const kMediaRemotePath =
     @"/System/Library/PrivateFrameworks/MediaRemote.framework/MediaRemote";
+
+/// Codes read live off a real session's `GetSupportedCommandsForPlayer` —
+/// not the old `MRMediaRemoteCommand` enum, which is not always the same
+/// numbering. Play/Pause/NextTrack/PreviousTrack happened to match it
+/// (0/1/4/5); SeekToPlaybackPosition did not (24, not the 11 the old enum
+/// would suggest). There is no separate toggle code in the per-client set —
+/// the caller sends Play or Pause explicitly, by its own known state.
+typedef NS_ENUM(int, MRCommand) {
+    MRCommandPlay = 0,
+    MRCommandPause = 1,
+    MRCommandNextTrack = 4,
+    MRCommandPreviousTrack = 5,
+    MRCommandSeekToPlaybackPosition = 24,
+};
 
 static void emit(NSDictionary *payload) {
     NSData *json = [NSJSONSerialization dataWithJSONObject:payload options:0 error:NULL];
@@ -88,14 +102,35 @@ static void publish(void) {
     });
 }
 
+/// The service already tracks which player is "active" for the whole
+/// system — asking it directly gives an already-resolved, already-matched
+/// path. Building one by hand from a bundle id resolves too, but the
+/// per-client API then reports it supports nothing and silently drops every
+/// command sent to it; this is the only form that has ever worked.
+/// `activePlayerPath` also answers nil until `MRMediaRemoteGetNowPlayingClients`
+/// has been called at least once in this process — `startFeed` does that once,
+/// at launch.
+static id activePlayerPath(void) {
+    id serviceClient = [NSClassFromString(@"MRMediaRemoteServiceClient") performSelector:@selector(sharedServiceClient)];
+    return [serviceClient performSelector:@selector(activePlayerPath)];
+}
+
+static void sendCommandToActivePlayer(MRCommand command, NSDictionary *options) {
+    if (!sSendCommandToPlayer) return;
+    id path = activePlayerPath();
+    if (!path) return;
+    sSendCommandToPlayer(command, (__bridge CFDictionaryRef)options, nil, path, nil, ^(id result){});
+}
+
 static void handleCommand(NSString *line) {
     if ([line isEqualToString:@"get"]) {
         publish();
     } else if ([line hasPrefix:@"cmd "]) {
-        if (sSendCommand) sSendCommand([line substringFromIndex:4].intValue, NULL);
+        sendCommandToActivePlayer((MRCommand)[line substringFromIndex:4].intValue, nil);
         publish();
     } else if ([line hasPrefix:@"seek "]) {
-        if (sSetElapsed) sSetElapsed([line substringFromIndex:5].doubleValue);
+        double seconds = [line substringFromIndex:5].doubleValue;
+        sendCommandToActivePlayer(MRCommandSeekToPlaybackPosition, @{@"kMRMediaRemoteOptionPlaybackPosition": @(seconds)});
         publish();
     }
 }
@@ -111,13 +146,18 @@ static void startFeed(void) {
         }
         sGetInfo = (MRGetInfoFn)dlsym(handle, "MRMediaRemoteGetNowPlayingInfo");
         sGetIsPlaying = (MRGetBoolFn)dlsym(handle, "MRMediaRemoteGetNowPlayingApplicationIsPlaying");
-        sSendCommand = (MRSendCommandFn)dlsym(handle, "MRMediaRemoteSendCommand");
-        sSetElapsed = (MRSetElapsedFn)dlsym(handle, "MRMediaRemoteSetElapsedTime");
         sGetPID = (MRGetPIDFn)dlsym(handle, "MRMediaRemoteGetNowPlayingApplicationPID");
+        sGetClients = (MRGetClientsFn)dlsym(handle, "MRMediaRemoteGetNowPlayingClients");
+        sSendCommandToPlayer = (MRSendCommandToPlayerFn)dlsym(handle, "MRMediaRemoteSendCommandToPlayer");
 
         MRRegisterFn registerNotifications =
             (MRRegisterFn)dlsym(handle, "MRMediaRemoteRegisterForNowPlayingNotifications");
         if (registerNotifications) registerNotifications(sQueue);
+
+        // activePlayerPath answers nil until the per-client subscription has
+        // been primed at least once in this process — call order matters,
+        // not just symbol presence.
+        if (sGetClients) sGetClients(sQueue, ^(NSArray *clients) {});
 
         NSArray *names = @[
             @"kMRMediaRemoteNowPlayingInfoDidChangeNotification",
@@ -132,6 +172,16 @@ static void startFeed(void) {
                 publish();
             }];
         }
+
+        // A poll, not just a subscription: on macOS 26 the notifications above
+        // were measured arriving zero times across 30-second windows that
+        // included real track changes (#23), so a client that only reacted to
+        // them would go stale silently. Cheap enough at this interval to run
+        // unconditionally rather than gate it on whether anything is playing —
+        // an idle session publishes the same empty record it already would.
+        [NSTimer scheduledTimerWithTimeInterval:2.0 repeats:YES block:^(NSTimer *timer) {
+            publish();
+        }];
 
         publish();
         [NSRunLoop.currentRunLoop addPort:[NSMachPort port] forMode:NSDefaultRunLoopMode];


### PR DESCRIPTION
Продолжение #23 — то, что там осталось непроверенным: play/pause/next/previous теми же кодами, и живая позиция.

**Проблема**

`MRMediaRemoteSendCommand` (глобальный, старый) на macOS 26 либо возвращает успех без эффекта, либо не доставляет ничего — уже измерено в #23. `MRMediaRemoteSetElapsedTime` та же история: переписывает запись демона, не двигая сам плеер. Seek через `SendCommandToPlayer`/`activePlayerPath` там же подтверждён рабочим; play/pause/next/previous тем же путём — нет, оставалось проверить.

**Правка**

Коды не унаследованы от старого `MRMediaRemoteCommand` — сняты вживую с `GetSupportedCommandsForPlayer` реальной играющей сессии (полный дамп: Play=0, Pause=1, SkipBackward=18, SkipForward=17, NextTrack=4, PreviousTrack=5, SeekToPlaybackPosition=24). Play/Pause/NextTrack/PreviousTrack совпали со старой нумерацией, seek — нет, что и объясняет, почему одно нельзя было переносить по аналогии с другим.

Отдельного `toggle`-кода в per-client наборе нет вообще. `MediaController.togglePlayPause()` и так уже флипает своё `isPlaying` оптимистично до отправки — теперь по этому же новому значению шлётся explicit Play или Pause, а не третий код.

Живая позиция — не через подписку, а через опрос: `kMRMediaRemote…DidChange`-уведомления на macOS 26 не приходят вообще (в #23 измерено — ноль за 30-секундные окна со сменами треков). Гоняться за альтернативной формой подписки не стал — добавил таймер раз в 2 секунды, который просто дёргает `publish()` безусловно. Дёшево, не завязано на то, работают ли уведомления в принципе, и ловит и смену трека, и паузу/воспроизведение, поставленные не через Cyclop (клавишей, самим плеером).

**Проверено**

Собрано, `swift build` + сборка хелпера чистые. Вживую, полный набор транспорта: play/pause, next, previous, перемотка кликом по полосе — все работают, ни одного диалога с разрешением за весь тест. Отдельно проверил именно живую позицию: поставил на паузу и сменил трек мимо Cyclop (в самом плеере) — панель подхватила это сама в пределах пары секунд, без открытия/закрытия.
