### PR TITLE
Настройки: отдельная вкладка в панели вместо статус-бара

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -9,16 +9,21 @@
 "Snippets" = "Snippets";
 "Calendar" = "Calendar";
 "Translate" = "Translate";
+"Settings" = "Settings";
 
 /* Menu bar */
 "Open Panel" = "Open Panel";
+"Quit" = "Quit";
+
+/* Settings tab */
+"General" = "General";
 "Launch at Login" = "Launch at Login";
+"Screenshots" = "Screenshots";
 "Save Clipboard Screenshots" = "Save Clipboard Screenshots";
 "Show Screenshots Folder" = "Show Screenshots Folder";
 "Clear Screenshots Folder" = "Clear Screenshots Folder";
 "Clear Screenshots Folder (%@)" = "Clear Screenshots Folder (%@)";
 "Show Snippets File" = "Show Snippets File";
-"Quit" = "Quit";
 
 /* Shelf */
 "Selected: %d" = "Selected: %d";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -8,16 +8,21 @@
 "Snippets" = "Заготовки";
 "Calendar" = "Календарь";
 "Translate" = "Перевод";
+"Settings" = "Настройки";
 
 /* Меню-бар */
 "Open Panel" = "Открыть панель";
+"Quit" = "Выйти";
+
+/* Вкладка настроек */
+"General" = "Общее";
 "Launch at Login" = "Запускать при входе";
+"Screenshots" = "Скриншоты";
 "Save Clipboard Screenshots" = "Сохранять скриншоты из буфера";
 "Show Screenshots Folder" = "Показать папку скриншотов";
 "Clear Screenshots Folder" = "Очистить папку снимков";
 "Clear Screenshots Folder (%@)" = "Очистить папку снимков (%@)";
 "Show Snippets File" = "Показать файл заготовок";
-"Quit" = "Выйти";
 
 /* Полка */
 "Selected: %d" = "Выбрано: %d";

--- a/Sources/Cyclop/App/AppDelegate.swift
+++ b/Sources/Cyclop/App/AppDelegate.swift
@@ -1,16 +1,12 @@
 import AppKit
-import ServiceManagement
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private var controller: NotchController?
     private var statusItem: NSStatusItem?
-    private var clearVaultItem: NSMenuItem?
     private var privacyItem: NSMenuItem?
     private var privacyAllItem: NSMenuItem?
     private var privacySectionItems: [PrivacyMode.Section: NSMenuItem] = [:]
-    private var loginItem: NSMenuItem?
-    private var saveShotsItem: NSMenuItem?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         controller = NotchController()
@@ -33,9 +29,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         item.button?.image?.isTemplate = true
 
         let menu = NSMenu()
-        // Enabling is decided here, not guessed from the responder chain: the
-        // clear item below is disabled exactly when the folder is empty.
-        menu.autoenablesItems = false
         menu.delegate = self
         menu.addItem(withTitle: "Cyclop \(Bundle.main.shortVersion)", action: nil, keyEquivalent: "")
         menu.addItem(.separator())
@@ -48,17 +41,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         toggle.target = self
         menu.addItem(toggle)
 
-        let login = NSMenuItem(
-            title: localized("Launch at Login"),
-            action: #selector(toggleLaunchAtLogin),
-            keyEquivalent: ""
-        )
-        login.target = self
-        login.state = launchAtLoginEnabled ? .on : .off
-        menu.addItem(login)
-        loginItem = login
-
-        // Sits next to the panel switch rather than among the folder items: it
+        // Sits next to the panel switch rather than in the Settings tab: it
         // changes what the panel shows, and it is the one people look for in a
         // hurry, with the camera already running.
         //
@@ -92,45 +75,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         menu.addItem(privacy)
         privacyItem = privacy
 
-        let saveShots = NSMenuItem(
-            title: localized("Save Clipboard Screenshots"),
-            action: #selector(toggleSaveClipboardImages),
-            keyEquivalent: ""
-        )
-        saveShots.target = self
-        saveShots.state = NotchViewModel.saveClipboardImagesEnabled ? .on : .off
-        menu.addItem(saveShots)
-        saveShotsItem = saveShots
-
-        let openFolder = NSMenuItem(
-            title: localized("Show Screenshots Folder"),
-            action: #selector(revealScreenshots),
-            keyEquivalent: ""
-        )
-        openFolder.target = self
-        menu.addItem(openFolder)
-
-        // Screenshots accumulate forever by design — nothing in that folder is
-        // deleted behind the user's back. This is the other half of that deal:
-        // one visible, hand-operated way out, with the current size right in
-        // the title so the offer names its price.
-        let clearVault = NSMenuItem(
-            title: localized("Clear Screenshots Folder"),
-            action: #selector(clearScreenshots),
-            keyEquivalent: ""
-        )
-        clearVault.target = self
-        menu.addItem(clearVault)
-        clearVaultItem = clearVault
-
-        let openSnippets = NSMenuItem(
-            title: localized("Show Snippets File"),
-            action: #selector(revealSnippets),
-            keyEquivalent: ""
-        )
-        openSnippets.target = self
-        menu.addItem(openSnippets)
-
         menu.addItem(.separator())
         let quit = NSMenuItem(title: localized("Quit"), action: #selector(quit), keyEquivalent: "q")
         quit.target = self
@@ -145,40 +89,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     /// Everything shown is re-read when the menu opens, not kept fresh in
-    /// between: a menu nobody is looking at deserves no bookkeeping — and a
-    /// state set once at launch quietly goes stale. Launch-at-login is the
-    /// live case: System Settings can switch it off from outside, and the
-    /// checkmark here used to keep claiming otherwise until relaunch (#11).
+    /// between: a menu nobody is looking at deserves no bookkeeping.
     func menuWillOpen(_ menu: NSMenu) {
         refreshPrivacyItems()
-        loginItem?.state = launchAtLoginEnabled ? .on : .off
-        saveShotsItem?.state = NotchViewModel.saveClipboardImagesEnabled ? .on : .off
-
-        guard let clearVaultItem else { return }
-        // Off the main thread: walking the folder takes as long as the folder
-        // is big, and this is the thread the whole panel lives on (#11). The
-        // menu is already open when the answer lands; the title updates in
-        // place.
-        DispatchQueue.global(qos: .userInitiated).async { [weak clearVaultItem] in
-            let usage = ScreenshotVault.usage()
-            let size = ByteCountFormatter.string(fromByteCount: usage.bytes, countStyle: .file)
-            DispatchQueue.main.async {
-                guard let clearVaultItem else { return }
-                if usage.files == 0 {
-                    clearVaultItem.title = localized("Clear Screenshots Folder")
-                    clearVaultItem.isEnabled = false
-                } else {
-                    clearVaultItem.title = localized("Clear Screenshots Folder (%@)", size)
-                    clearVaultItem.isEnabled = true
-                }
-            }
-        }
-    }
-
-    @objc private func clearScreenshots() {
-        ScreenshotVault.clear()
-        // The cards pointing into that folder just went to the Trash with it.
-        controller?.reloadShelf()
     }
 
     @objc private func quit() {
@@ -212,39 +125,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         for (section, item) in privacySectionItems {
             item.state = privacy.covers(section) ? .on : .off
         }
-    }
-
-    @objc private func toggleSaveClipboardImages(_ sender: NSMenuItem) {
-        UserDefaults.standard.set(
-            !NotchViewModel.saveClipboardImagesEnabled,
-            forKey: NotchViewModel.saveClipboardImagesKey
-        )
-        sender.state = NotchViewModel.saveClipboardImagesEnabled ? .on : .off
-    }
-
-    @objc private func revealScreenshots() {
-        ScreenshotVault.reveal()
-    }
-
-    @objc private func revealSnippets() {
-        SnippetStore.reveal()
-    }
-
-    private var launchAtLoginEnabled: Bool {
-        SMAppService.mainApp.status == .enabled
-    }
-
-    @objc private func toggleLaunchAtLogin(_ sender: NSMenuItem) {
-        do {
-            if launchAtLoginEnabled {
-                try SMAppService.mainApp.unregister()
-            } else {
-                try SMAppService.mainApp.register()
-            }
-        } catch {
-            NSLog("Cyclop: launch-at-login failed: \(error.localizedDescription)")
-        }
-        sender.state = launchAtLoginEnabled ? .on : .off
     }
 }
 

--- a/Sources/Cyclop/Model/NotchViewModel.swift
+++ b/Sources/Cyclop/Model/NotchViewModel.swift
@@ -4,7 +4,7 @@ import Combine
 @MainActor
 final class NotchViewModel: ObservableObject {
     enum Tab: String, CaseIterable, Identifiable {
-        case media, shelf, clipboard, snippets, calendar, translate, notes
+        case media, shelf, clipboard, snippets, calendar, translate, notes, settings
         var id: String { rawValue }
 
         var symbol: String {
@@ -16,6 +16,7 @@ final class NotchViewModel: ObservableObject {
             case .calendar: return "calendar"
             case .translate: return "translate"
             case .notes: return "note.text"
+            case .settings: return "gearshape.fill"
             }
         }
 
@@ -28,6 +29,7 @@ final class NotchViewModel: ObservableObject {
             case .calendar: return localized("Calendar")
             case .translate: return localized("Translate")
             case .notes: return localized("Notes")
+            case .settings: return localized("Settings")
             }
         }
 
@@ -38,9 +40,12 @@ final class NotchViewModel: ObservableObject {
         /// Which rail the icon sits on. The left one carries the original six
         /// and is full — a seventh icon would outgrow the height the panel
         /// body has — so growth continues in a second column on the right,
-        /// which the scratch notes open.
+        /// which the scratch notes open. Settings joins that column rather
+        /// than the content rail: it is not something to hover past on the
+        /// way to a track or a calendar, so it sits last, furthest from the
+        /// tabs people actually rest on.
         static let leftRail: [Tab] = [.media, .shelf, .clipboard, .snippets, .calendar, .translate]
-        static let rightRail: [Tab] = [.notes]
+        static let rightRail: [Tab] = [.notes, .settings]
     }
 
     @Published var isOpen = false

--- a/Sources/Cyclop/Notch/NotchController.swift
+++ b/Sources/Cyclop/Notch/NotchController.swift
@@ -54,12 +54,6 @@ final class NotchController {
         }
     }
 
-    /// The screenshots folder can be emptied from the menu bar; the shelf has
-    /// to notice its files are gone without waiting for a relaunch.
-    func reloadShelf() {
-        viewModel?.shelf.load()
-    }
-
     /// The panel belongs to the desktop it was opened on. ⌘-Tab to another one
     /// leaves the pointer wherever it happened to be — which is not a decision
     /// to keep the panel expanded over a screen the user has just arrived at.

--- a/Sources/Cyclop/Services/SnippetStore.swift
+++ b/Sources/Cyclop/Services/SnippetStore.swift
@@ -158,7 +158,14 @@ final class SnippetStore: ObservableObject {
         pasteboard.setString(snippet.text, forType: .string)
     }
 
+    /// Selecting a file that is not on disk yet is a silent no-op for Finder —
+    /// nothing opens, nothing errors. Before the first snippet is added there
+    /// is nothing to select, so an empty list is written first: the same
+    /// state `reload()` already treats as a valid, empty file.
     static func reveal() {
+        if !FileManager.default.fileExists(atPath: file.path) {
+            try? Data("[]".utf8).write(to: file)
+        }
         NSWorkspace.shared.activateFileViewerSelecting([file])
     }
 }

--- a/Sources/Cyclop/UI/NotchContentView.swift
+++ b/Sources/Cyclop/UI/NotchContentView.swift
@@ -96,6 +96,8 @@ struct NotchContentView: View {
             EmptyView()
         case .notes:
             NotesCounter(notes: vm.notes)
+        case .settings:
+            EmptyView()
         }
     }
 
@@ -157,6 +159,8 @@ struct NotchContentView: View {
             TranslatePane(translator: vm.translator, wantsKeyboard: $vm.wantsKeyboard)
         case .notes:
             NotesPane(notes: vm.notes, privacy: vm.privacy, wantsKeyboard: $vm.wantsKeyboard)
+        case .settings:
+            SettingsPane(shelf: vm.shelf)
         }
     }
 }

--- a/Sources/Cyclop/UI/SettingsPane.swift
+++ b/Sources/Cyclop/UI/SettingsPane.swift
@@ -1,0 +1,176 @@
+import SwiftUI
+import ServiceManagement
+
+/// What used to live in the status bar menu, minus the two items that belong
+/// there: opening the panel and hiding its contents are both things people
+/// reach for in a hurry, often without wanting to open the panel at all — the
+/// rest is configuration, read rarely, and reads better as a tab like any
+/// other than as a menu that grows a new row per feature.
+struct SettingsPane: View {
+    @ObservedObject var shelf: ShelfStore
+
+    @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
+    @State private var saveClipboardImages = NotchViewModel.saveClipboardImagesEnabled
+    @State private var screenshotUsage: (files: Int, bytes: Int64) = (0, 0)
+
+    var body: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 14) {
+                section(localized("General")) {
+                    toggleRow(
+                        symbol: "arrow.forward.to.line",
+                        title: localized("Launch at Login"),
+                        isOn: launchAtLoginBinding
+                    )
+                }
+
+                section(localized("Screenshots")) {
+                    toggleRow(
+                        symbol: "photo.on.rectangle",
+                        title: localized("Save Clipboard Screenshots"),
+                        isOn: saveClipboardImagesBinding
+                    )
+                    actionRow(symbol: "folder", title: localized("Show Screenshots Folder")) {
+                        ScreenshotVault.reveal()
+                    }
+                    actionRow(
+                        symbol: "trash",
+                        title: clearTitle,
+                        disabled: screenshotUsage.files == 0
+                    ) {
+                        ScreenshotVault.clear()
+                        shelf.load()
+                        refreshUsage()
+                    }
+                }
+
+                section(localized("Snippets")) {
+                    actionRow(symbol: "doc.text", title: localized("Show Snippets File")) {
+                        SnippetStore.reveal()
+                    }
+                }
+            }
+            .padding(.top, 2)
+            .padding(.trailing, 4)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        // Live state, not a snapshot taken once at launch: System Settings can
+        // flip Launch at Login from outside, and the folder can empty or fill
+        // between visits to this tab (#11 taught the same lesson for the menu
+        // this replaces).
+        .onAppear {
+            launchAtLogin = SMAppService.mainApp.status == .enabled
+            saveClipboardImages = NotchViewModel.saveClipboardImagesEnabled
+            refreshUsage()
+        }
+    }
+
+    private var clearTitle: String {
+        guard screenshotUsage.files > 0 else { return localized("Clear Screenshots Folder") }
+        let size = ByteCountFormatter.string(fromByteCount: screenshotUsage.bytes, countStyle: .file)
+        return localized("Clear Screenshots Folder (%@)", size)
+    }
+
+    private var launchAtLoginBinding: Binding<Bool> {
+        Binding(
+            get: { launchAtLogin },
+            set: { wants in
+                do {
+                    if wants {
+                        try SMAppService.mainApp.register()
+                    } else {
+                        try SMAppService.mainApp.unregister()
+                    }
+                } catch {
+                    NSLog("Cyclop: launch-at-login failed: \(error.localizedDescription)")
+                }
+                launchAtLogin = SMAppService.mainApp.status == .enabled
+            }
+        )
+    }
+
+    private var saveClipboardImagesBinding: Binding<Bool> {
+        Binding(
+            get: { saveClipboardImages },
+            set: { wants in
+                saveClipboardImages = wants
+                UserDefaults.standard.set(wants, forKey: NotchViewModel.saveClipboardImagesKey)
+            }
+        )
+    }
+
+    /// Off the main thread: walking the folder takes as long as the folder is
+    /// big, and this is the thread the whole panel lives on (#11).
+    private func refreshUsage() {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let usage = ScreenshotVault.usage()
+            DispatchQueue.main.async { screenshotUsage = usage }
+        }
+    }
+
+    // MARK: - Rows
+
+    @ViewBuilder
+    private func section<Rows: View>(_ title: String, @ViewBuilder rows: () -> Rows) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title.uppercased())
+                .font(.system(size: 9, weight: .semibold))
+                .tracking(0.6)
+                .foregroundStyle(Theme.tertiary)
+                .padding(.leading, 8)
+            VStack(spacing: 1) {
+                rows()
+            }
+            .padding(4)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(Theme.surface)
+            )
+        }
+    }
+
+    private func toggleRow(symbol: String, title: String, isOn: Binding<Bool>) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: symbol)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Theme.secondary)
+                .frame(width: 16)
+            Text(title)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(.white)
+            Spacer(minLength: 8)
+            Toggle("", isOn: isOn)
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .labelsHidden()
+        }
+        .padding(.horizontal, 8)
+        .frame(height: 26)
+    }
+
+    private func actionRow(
+        symbol: String,
+        title: String,
+        disabled: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: symbol)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Theme.secondary)
+                    .frame(width: 16)
+                Text(title)
+                    .font(.system(size: 11.5, weight: .medium))
+                    .foregroundStyle(.white)
+                Spacer(minLength: 8)
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 26)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .opacity(disabled ? 0.4 : 1)
+    }
+}


### PR DESCRIPTION
Реализация к #40 — если подход там не одобрят, закрывай вместе с issue.

**Зачем**

Статус-бар меню обрастает пунктами: сейчас там Launch at Login, Save Clipboard Screenshots, Show/Clear Screenshots Folder, Show Snippets File — вперемешку с тем, что действительно нужно быстро (открыть панель, спрятать содержимое). Открытый #13 добавил бы ещё три пункта (плавность переключения, чеклист видимых вкладок, второй монитор) — меню фактически стало бы панелью настроек поверх NSMenu.

А NSMenu для этого — не лучший выбор. В #38 чеклист календарей сначала сделал там же, где Hide Contents, и вживую оказалось неудобно: меню закрывается после каждого клика, для нескольких переключений подряд приходится открывать заново. То же самое ждало бы чеклист вкладок из #13.

**Правка**

Новая вкладка Settings (шестерёнка, справа рядом с Notes) — SwiftUI-версия того же списка, не закрывающаяся после клика. Три секции: General (Launch at Login), Screenshots (сохранение, папка, очистка), Snippets (файл).

В статус-баре остаётся то, что не требует открывать панель: Open Panel, Hide Contents (само по себе — «то, что ищут второпях», как написано в комментарии рядом, когда кто-то смотрит на экран) и Quit.

Заодно (нашлось при живом тестировании перенесённой кнопки): `SnippetStore.reveal()` тихо ничего не делал, если `snippets.json` ещё не создан — Finder не может выделить несуществующий файл, а до первой сохранённой заготовки файла и нет. На чистой машине это как раз путь, которым идёт перенесённая кнопка. Поправил: перед показом создаёт пустой список — то же самое состояние, которое `reload()` уже считает валидным пустым файлом.

**Проверено**

Собрано, ключи локализации сверены локально тем же скриптом, что в CI. Вживую: меню статус-бара стало коротким — только Open Panel / Hide Contents / Quit; вкладка Settings открывается по клику на шестерёнку, тумблеры Launch at Login и Save Clipboard Screenshots переключаются без сдвига вёрстки, «Show Screenshots Folder» и «Clear Screenshots Folder» работают на реальной папке снимков, «Show Snippets File» открывает Finder на пустом `snippets.json` (после фикса).
