### PR TITLE
Панель закрывается без задержки; переключатели в настройках — не серые

### DIFF
--- a/Sources/Cyclop/Notch/PointerWatcher.swift
+++ b/Sources/Cyclop/Notch/PointerWatcher.swift
@@ -28,7 +28,7 @@ final class PointerWatcher {
     /// Short enough to feel immediate, long enough that a pointer sweeping
     /// across the top of the screen does not trigger the panel.
     var openDelay: TimeInterval = 0.05
-    var closeDelay: TimeInterval = 0.32
+    var closeDelay: TimeInterval = 0.05
 
     /// Band along the top of the screen that switches sampling to full rate.
     /// The pointer has to cross it to reach the notch, so the fast rate is

--- a/Sources/Cyclop/UI/SettingsPane.swift
+++ b/Sources/Cyclop/UI/SettingsPane.swift
@@ -140,8 +140,7 @@ struct SettingsPane: View {
                 .foregroundStyle(.white)
             Spacer(minLength: 8)
             Toggle("", isOn: isOn)
-                .toggleStyle(.switch)
-                .controlSize(.mini)
+                .toggleStyle(NotchToggleStyle())
                 .labelsHidden()
         }
         .padding(.horizontal, 8)

--- a/Sources/Cyclop/UI/Theme.swift
+++ b/Sources/Cyclop/UI/Theme.swift
@@ -48,6 +48,31 @@ extension View {
     }
 }
 
+/// Drawn rather than `NSSwitch`-backed: the panel is a non-activating window
+/// that almost never becomes key (that is what keeps hovering it from
+/// stealing focus from whatever app was in front), and `NSSwitch` renders its
+/// on-state in gray rather than accent blue whenever its window is not key.
+/// A plain `Color` fill has no such state to lose.
+struct NotchToggleStyle: ToggleStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        Button {
+            configuration.isOn.toggle()
+        } label: {
+            Capsule()
+                .fill(configuration.isOn ? Color.accentColor : Theme.surfaceHover)
+                .frame(width: 28, height: 16)
+                .overlay(
+                    Circle()
+                        .fill(.white)
+                        .frame(width: 12, height: 12)
+                        .offset(x: configuration.isOn ? 6 : -6)
+                )
+        }
+        .buttonStyle(.plain)
+        .animation(.easeOut(duration: 0.15), value: configuration.isOn)
+    }
+}
+
 func formatTime(_ seconds: TimeInterval) -> String {
     guard seconds.isFinite, seconds >= 0 else { return "--:--" }
     let total = Int(seconds.rounded())


### PR DESCRIPTION
closeDelay стоял в 0.32с, вчетверо дольше openDelay: открытие ощущалось мгновенным, закрытие — тормозным. Поднят до тех же 0.05с.

Toggle со стилем .switch — это NSSwitch, а тот красит себя в акцентный синий только пока его окно key. NotchPanel — non-activating panel, key почти никогда не становится (иначе наведение отбирало бы фокус у активного приложения), так что включённый тумблер в Settings всегда выглядел серым, как выключенный. NotchToggleStyle рисует переключатель сам — заливка Color, а не системный контрол, так что от key-статуса окна больше не зависит.