### PR TITLE
Панель не остаётся раскрытой после того, как отдала клавиатуру

### DIFF
--- a/Sources/Cyclop/Notch/NotchController.swift
+++ b/Sources/Cyclop/Notch/NotchController.swift
@@ -249,7 +249,15 @@ final class NotchController {
         panel?.acceptsKeyboard = wants
         // What was typed stays: clicking away to look something up should not
         // be the same as throwing the text out. Esc and the ✕ do that.
-        if !wants { scheduleCollapseIfPointerAway() }
+        if !wants {
+            // An open panel hands the keyboard back in `collapse`, after the
+            // fold — see `NotchPanel.releaseKey`. Closed, there is no animation
+            // to protect, so it goes at once.
+            if viewModel?.isOpen != true {
+                DispatchQueue.main.async { [weak self] in self?.panel?.releaseKey() }
+            }
+            scheduleCollapseIfPointerAway()
+        }
     }
 
     /// The pointer decides, almost always. A field with something in it does
@@ -315,6 +323,23 @@ final class NotchController {
         withAnimation(Theme.openAnimation) { vm.isOpen = false }
         vm.media.setActive(false)
         vm.calendar.setActive(false)
+
+        // The keyboard goes back only now, a pass after the fold has started.
+        // Done earlier — straight from `acceptsKeyboard`, as it used to be — the
+        // window's round trip landed in the middle of the fold and took its
+        // repaint with it: the panel stood expanded with `isOpen` already false.
+        //
+        // The repaint is then asked for outright. Even if some future order of
+        // events loses it again, the picture must not be left disagreeing with
+        // the state: that disagreement is what made the panel unclosable and its
+        // buttons dead, since clicks land by state and the drawing said other.
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.panel?.releaseKey()
+            self.viewModel?.objectWillChange.send()
+            self.rootView?.needsDisplay = true
+            self.panel?.displayIfNeeded()
+        }
         // Shrink only once the panel has finished collapsing. Doing it
         // while it is still visibly there would leave a window in which
         // clicks land on whatever is behind the panel.

--- a/Sources/Cyclop/Notch/NotchPanel.swift
+++ b/Sources/Cyclop/Notch/NotchPanel.swift
@@ -12,17 +12,30 @@ final class NotchPanel: NSPanel {
     var acceptsKeyboard = false {
         didSet {
             guard acceptsKeyboard != oldValue else { return }
-            if acceptsKeyboard {
-                makeKey()
-            } else if isKeyWindow {
-                // There is no supported way to simply hand key status back, and
-                // this app owns no other window to pass it to. Ordering out and
-                // straight back in resigns it; the panel is borderless and the
-                // round trip happens within one pass, so nothing flickers.
-                orderOut(nil)
-                orderFrontRegardless()
-            }
+            if acceptsKeyboard { makeKey() }
+            // Giving it back is `releaseKey`, called separately — when it
+            // happens matters, and only the controller knows when it is safe.
         }
+    }
+
+    /// Hands the key status back.
+    ///
+    /// There is no supported way to simply give it up, and this app owns no
+    /// other window to pass it to. Ordering out and straight back in resigns it;
+    /// the panel is borderless and the round trip happens within one pass, so
+    /// nothing flickers.
+    ///
+    /// Deliberately not done from `acceptsKeyboard`. That round trip pulls the
+    /// window out from under whatever is drawing into it, and when it landed
+    /// before the fold, the fold's animation lost its repaint: the panel stayed
+    /// on screen fully expanded with `isOpen` already false — ignoring the
+    /// pointer, since there was nothing left to close, and passing clicks
+    /// through to the app underneath, since the interactive area had shrunk to
+    /// the notch while the picture still showed a panel.
+    func releaseKey() {
+        guard !acceptsKeyboard, isKeyWindow else { return }
+        orderOut(nil)
+        orderFrontRegardless()
     }
 
     override var canBecomeKey: Bool { acceptsKeyboard }


### PR DESCRIPTION
Панель иногда остаётся на экране раскрытой после того, как логически уже закрылась: `isOpen` — `false`, а картинка прежняя.

Наружу это выглядит как два разных бага:

- **панель не закрывается.** Уводишь курсор — она висит. Помогает только переключение на другую вкладку или что угодно, вызывающее перерисовку;
- **кнопки в ней перестают работать.** Клик по крестику в переводе уходит в приложение под панелью: интерактивная область уже сжалась до чёлки вместе с состоянием, а нарисованная панель осталась большой.

Чаще всего ловится на вкладке перевода — там панель забирает и отдаёт клавиатуру чаще остальных.

## Причина

Ключевой статус отдаётся единственным доступным способом — `orderOut` + `orderFrontRegardless`, то есть окно на миг выдёргивается и возвращается. Делалось это прямо из `didSet` у `acceptsKeyboard`, а `collapse()` приходит следующим проходом цикла — то есть выдёргивание окна попадает ровно в момент анимации сворачивания и уносит её перерисовку. Состояние применяется, картинка остаётся прежней.

Это тот же класс проблемы, который уже описан в комментарии к `setOpen` — там клавиатура и сворачивание разведены по разным проходам именно поэтому. Разведены, но в неудачном порядке: выдёргивание окна по-прежнему происходит перед сворачиванием, а не после.

## Что меняется

1. `releaseKey()` вынесен из `acceptsKeyboard` в отдельный метод — момент, когда окно делает круг, теперь выбирает контроллер.
2. `collapse()` зовёт его **после** сворачивания, следующим проходом. Пока панель закрыта, клавиатура отдаётся сразу, как и раньше: там анимации нет и защищать нечего.
3. После сворачивания перерисовка запрашивается явно. Это страховка: даже если порядок событий когда-нибудь снова сложится неудачно, картинка не сможет остаться раскрытой при закрытом состоянии — а именно это расхождение и делало панель неуправляемой.

## Как воспроизвести до правки

1. Навести на чёлку, открыть перевод, набрать что-нибудь.
2. Кликнуть мышью в другое окно и продолжить работать там.
3. Панель остаётся раскрытой, курсор на неё больше не влияет, клик по её крестику уходит в окно под ней.

Воспроизводится не каждый раз — нужен определённый порядок событий внутри одного прохода цикла.

## Как проверялось

Диагностика логами в `setOpen`, `collapse`, `setKeyboard`, `pointer.onChange` и в опросе курсора, плюс снимок состояния раз в две секунды, пока панель открыта. Решающим оказалось отсутствие этих снимков в момент, когда панель висела на экране: значит `isOpen` уже `false`, и расхождение именно между состоянием и картинкой, а не в логике закрытия.

После правки сценарий выше не воспроизводится: панель уходит через треть секунды после того, как курсор её покинул, и кнопки работают.
