### PR TITLE
Блокировка клавиатуры и трекпада, чтобы протереть их

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -99,3 +99,21 @@
 "Paste the script here" = "Paste the script here";
 "Ready" = "Ready";
 "Done" = "Done";
+
+/* Utilities */
+"Utilities" = "Utilities";
+"Lock Keyboard" = "Lock Keyboard";
+"Wipe the keys and the screen. Hold Esc or − for %d s to\nunlock; it also unlocks by itself after a minute" = "Wipe the keys and the screen. Hold Esc or − for %d s to\nunlock; it also unlocks by itself after a minute";
+"Allow in Settings" = "Allow in Settings";
+"Input is protected" = "Input is protected";
+"Could not take over input" = "Could not take over input";
+"Still unlocking" = "Still unlocking";
+"Lock ended early" = "Lock ended early";
+"An app turned on secure keyboard entry, so keys stopped\nreaching the lock. It ended instead of pretending" = "An app turned on secure keyboard entry, so keys stopped\nreaching the lock. It ended instead of pretending";
+"The previous lock is still being taken down.\nPress again in a moment" = "The previous lock is still being taken down.\nPress again in a moment";
+"An app is holding secure keyboard entry — a password field,\na password manager, a terminal. Close it and press again" = "An app is holding secure keyboard entry — a password field,\na password manager, a terminal. Close it and press again";
+"The system refused the event tap. Re-granting Accessibility\nusually fixes it — the permission is tied to the app's signature" = "The system refused the event tap. Re-granting Accessibility\nusually fixes it — the permission is tied to the app's signature";
+"Cyclop needs Accessibility to swallow keys and clicks.\nSystem Settings → Privacy & Security → Accessibility" = "Cyclop needs Accessibility to swallow keys and clicks.\nSystem Settings → Privacy & Security → Accessibility";
+"Keyboard and trackpad are locked" = "Keyboard and trackpad are locked";
+"Hold Esc or − for %d s" = "Hold Esc or − for %d s";
+"Unlocks by itself in %d s" = "Unlocks by itself in %d s";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -98,3 +98,21 @@
 "Paste the script here" = "Вставьте сюда сценарий";
 "Ready" = "Готово";
 "Done" = "Готово";
+
+/* Утилиты */
+"Utilities" = "Утилиты";
+"Lock Keyboard" = "Заблокировать клавиатуру";
+"Wipe the keys and the screen. Hold Esc or − for %d s to\nunlock; it also unlocks by itself after a minute" = "Протри клавиши и экран. Чтобы разблокировать — держи Esc\nили − %d с; само снимется через минуту";
+"Allow in Settings" = "Разрешить в настройках";
+"Input is protected" = "Ввод защищён";
+"Could not take over input" = "Не удалось перехватить ввод";
+"Still unlocking" = "Ещё разблокируется";
+"Lock ended early" = "Блокировка прервалась";
+"An app turned on secure keyboard entry, so keys stopped\nreaching the lock. It ended instead of pretending" = "Приложение включило защищённый ввод, и нажатия перестали\nдоходить до блокировки. Она снялась, а не сделала вид";
+"The previous lock is still being taken down.\nPress again in a moment" = "Предыдущая блокировка ещё снимается.\nНажми снова через мгновение";
+"An app is holding secure keyboard entry — a password field,\na password manager, a terminal. Close it and press again" = "Какое-то приложение держит защищённый ввод — поле пароля,\nменеджер паролей, терминал. Закрой его и нажми снова";
+"The system refused the event tap. Re-granting Accessibility\nusually fixes it — the permission is tied to the app's signature" = "Система не дала перехват событий. Обычно помогает выдать\nУниверсальный доступ заново — он привязан к подписи сборки";
+"Cyclop needs Accessibility to swallow keys and clicks.\nSystem Settings → Privacy & Security → Accessibility" = "Нужен Универсальный доступ, чтобы гасить нажатия и клики.\nНастройки → Конфиденциальность → Универсальный доступ";
+"Keyboard and trackpad are locked" = "Клавиатура и трекпад заблокированы";
+"Hold Esc or − for %d s" = "Держи Esc или − %d с";
+"Unlocks by itself in %d s" = "Само снимется через %d с";

--- a/Sources/Cyclop/Model/NotchViewModel.swift
+++ b/Sources/Cyclop/Model/NotchViewModel.swift
@@ -4,7 +4,7 @@ import Combine
 @MainActor
 final class NotchViewModel: ObservableObject {
     enum Tab: String, CaseIterable, Identifiable {
-        case media, shelf, clipboard, snippets, calendar, translate, notes, teleprompter, settings
+        case media, shelf, clipboard, snippets, calendar, translate, notes, teleprompter, utilities, settings
         var id: String { rawValue }
 
         var symbol: String {
@@ -17,6 +17,7 @@ final class NotchViewModel: ObservableObject {
             case .translate: return "translate"
             case .notes: return "note.text"
             case .teleprompter: return "text.viewfinder"
+            case .utilities: return "wrench.and.screwdriver.fill"
             case .settings: return "gearshape.fill"
             }
         }
@@ -31,6 +32,7 @@ final class NotchViewModel: ObservableObject {
             case .translate: return localized("Translate")
             case .notes: return localized("Notes")
             case .teleprompter: return localized("Teleprompter")
+            case .utilities: return localized("Utilities")
             case .settings: return localized("Settings")
             }
         }
@@ -49,7 +51,7 @@ final class NotchViewModel: ObservableObject {
         /// past on the way to a track or a calendar, so it sits last,
         /// furthest from the tabs people actually rest on.
         static let leftRail: [Tab] = [.media, .shelf, .clipboard, .snippets, .calendar, .translate]
-        static let rightRail: [Tab] = [.notes, .teleprompter, .settings]
+        static let rightRail: [Tab] = [.notes, .teleprompter, .utilities, .settings]
     }
 
     @Published var isOpen = false
@@ -115,8 +117,17 @@ final class NotchViewModel: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
 
-    init(geometry: NotchGeometry) {
+    /// Owned by the controller, not by this model.
+    ///
+    /// Everything else here is panel state, and the model is thrown away and
+    /// rebuilt whenever the display geometry changes — fine for a selected tab
+    /// and fatal for a lock: plugging in a monitor mid-wipe would drop the tap
+    /// and the cover while the cloth was still on the keys.
+    let keyboardLock: KeyboardLock
+
+    init(geometry: NotchGeometry, keyboardLock: KeyboardLock) {
         self.geometry = geometry
+        self.keyboardLock = keyboardLock
         self.media = MediaController()
         self.shelf = ShelfStore()
         self.clipboard = ClipboardStore()

--- a/Sources/Cyclop/Notch/CleaningOverlay.swift
+++ b/Sources/Cyclop/Notch/CleaningOverlay.swift
@@ -1,0 +1,137 @@
+import AppKit
+import SwiftUI
+
+/// Black cover over every display for as long as the input is locked.
+///
+/// It earns its place twice: it is the only proof the lock is on — a locked Mac
+/// that looks ordinary is indistinguishable from a frozen one — and a black
+/// screen is what shows the smudges, so the display gets wiped in the same pass
+/// as the keys.
+@MainActor
+final class CleaningOverlay {
+    private var windows: [NSWindow] = []
+    private var observer: Any?
+
+    func show(lock: KeyboardLock) {
+        guard windows.isEmpty else { return }
+        build(lock: lock)
+        // Plugging in a display mid-wipe would otherwise leave it uncovered, and
+        // an uncovered display is a Mac that looks unlocked while it is not.
+        observer = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self, !self.windows.isEmpty else { return }
+                self.teardown()
+                self.build(lock: lock)
+            }
+        }
+    }
+
+    func hide() {
+        if let observer { NotificationCenter.default.removeObserver(observer) }
+        observer = nil
+        teardown()
+    }
+
+    private func build(lock: KeyboardLock) {
+        let screens = NSScreen.screens
+        // Decided once, before the loop. Asking each screen in turn whether it
+        // holds the pointer *or* happens to be the first one made two screens
+        // answer yes as soon as the pointer was on the second: the message was
+        // then drawn twice, on different displays.
+        let messageIndex = screens.firstIndex { $0.frame.contains(NSEvent.mouseLocation) } ?? 0
+
+        for (index, screen) in screens.enumerated() {
+            // Built at zero and framed afterwards, deliberately. The initialiser
+            // that takes a `screen:` reads the rect relative to that screen's own
+            // lower-left corner, so handing it `screen.frame` — which is already
+            // global — adds the origin to itself: a second display at x=1728 got
+            // a cover at x=3456, hanging off the side and leaving most of the
+            // screen bare. `setFrame` is global and needs no such translation.
+            let window = NSWindow(
+                contentRect: .zero,
+                styleMask: [.borderless],
+                backing: .buffered,
+                defer: false
+            )
+            window.setFrame(screen.frame, display: false)
+            window.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+            window.backgroundColor = .black
+            window.isOpaque = true
+            window.hasShadow = false
+            window.ignoresMouseEvents = true
+            window.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
+            window.appearance = NSAppearance(named: .darkAqua)
+            window.animationBehavior = .none
+
+            // The message goes on the screen the pointer is on, so it is read
+            // where the person is looking; the rest stay plain black.
+            let hosting = NSHostingView(
+                rootView: CleaningOverlayView(lock: lock, showsMessage: index == messageIndex)
+            )
+            hosting.frame = CGRect(origin: .zero, size: screen.frame.size)
+            hosting.autoresizingMask = [.width, .height]
+            window.contentView = hosting
+            window.orderFrontRegardless()
+            windows.append(window)
+        }
+    }
+
+    private func teardown() {
+        for window in windows {
+            window.contentView = nil
+            window.orderOut(nil)
+        }
+        windows.removeAll()
+    }
+}
+
+private struct CleaningOverlayView: View {
+    @ObservedObject var lock: KeyboardLock
+    let showsMessage: Bool
+
+    var body: some View {
+        ZStack {
+            Color.black
+            if showsMessage {
+                VStack(spacing: 18) {
+                    Image(systemName: "keyboard")
+                        .font(.system(size: 34, weight: .thin))
+                        .foregroundStyle(Color.white.opacity(0.55))
+
+                    Text(localized("Keyboard and trackpad are locked"))
+                        .font(.system(size: 17, weight: .medium))
+                        .foregroundStyle(Color.white.opacity(0.85))
+
+                    Text(localized("Hold Esc or − for %d s", Int(KeyboardLock.holdToRelease)))
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color.white.opacity(0.45))
+
+                    hold
+
+                    Text(localized("Unlocks by itself in %d s", lock.secondsLeft))
+                        .font(.system(size: 11).monospacedDigit())
+                        .foregroundStyle(Color.white.opacity(0.3))
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// Shows the hold as it accumulates: without it a three-second press is
+    /// indistinguishable from a lock that stopped answering.
+    private var hold: some View {
+        ZStack(alignment: .leading) {
+            Capsule()
+                .fill(Color.white.opacity(0.12))
+            Capsule()
+                .fill(Color.white.opacity(0.7))
+                .frame(width: 180 * lock.holdProgress)
+        }
+        .frame(width: 180, height: 4)
+        .animation(.linear(duration: 1.0 / 20), value: lock.holdProgress)
+    }
+}

--- a/Sources/Cyclop/Notch/NotchController.swift
+++ b/Sources/Cyclop/Notch/NotchController.swift
@@ -8,6 +8,10 @@ final class NotchController {
     private var rootView: NotchRootView?
     private var viewModel: NotchViewModel?
     private let pointer = PointerWatcher()
+    private let cleaning = CleaningOverlay()
+    /// Lives here rather than in the view model, which is rebuilt on every
+    /// change of display geometry. See `NotchViewModel.keyboardLock`.
+    private let keyboardLock = KeyboardLock()
     private var closeActiveRectWork: DispatchWorkItem?
     private var cancellables = Set<AnyCancellable>()
     /// Monotonic stamp for the deferred half of closing: any newer open or
@@ -78,6 +82,9 @@ final class NotchController {
 
     func teardown() {
         pointer.stop()
+        // Quitting mid-wipe must not leave the tap installed.
+        keyboardLock.unlock()
+        cleaning.hide()
         viewModel?.stop()
         panel?.acceptsKeyboard = false
         panel?.orderOut(nil)
@@ -109,7 +116,7 @@ final class NotchController {
 
     private func build() {
         let geometry = NotchGeometry.current()
-        let vm = NotchViewModel(geometry: geometry)
+        let vm = NotchViewModel(geometry: geometry, keyboardLock: keyboardLock)
         viewModel = vm
 
         let panel = NotchPanel(contentRect: geometry.windowFrame)
@@ -216,6 +223,27 @@ final class NotchController {
             .removeDuplicates()
             .sink { [weak self] wants in
                 MainActor.assumeIsolated { self?.setKeyboard(wants) }
+            }
+            .store(in: &cancellables)
+
+        // The lock covers every display and swallows the pointer, so the panel
+        // has no business standing open underneath it — and hover tracking has
+        // nothing to track until the pointer can move again.
+        keyboardLock.$isLocked
+            .removeDuplicates()
+            .sink { [weak self] locked in
+                MainActor.assumeIsolated {
+                    guard let self else { return }
+                    if locked {
+                        self.setOpen(false)
+                        self.pointer.setInside(false)
+                        self.pointer.stop()
+                        self.cleaning.show(lock: self.keyboardLock)
+                    } else {
+                        self.cleaning.hide()
+                        self.pointer.start()
+                    }
+                }
             }
             .store(in: &cancellables)
 

--- a/Sources/Cyclop/Services/KeyboardLock.swift
+++ b/Sources/Cyclop/Services/KeyboardLock.swift
@@ -1,0 +1,348 @@
+import AppKit
+import ApplicationServices
+import Carbon
+
+/// Swallows every input event so the keyboard and trackpad can be wiped.
+///
+/// The only mechanism that can actually stop an event from reaching the system
+/// is a `CGEventTap` in its default, non-listening mode — and that one is gated
+/// behind the Accessibility permission. Anything cheaper only steals the focus:
+/// the app would look locked while ⌘Q, ⌘Tab and the brightness keys still went
+/// through, which is worse than not offering the feature, because a cloth is
+/// trusted against a promise that does not hold.
+@MainActor
+final class KeyboardLock: ObservableObject {
+    @Published private(set) var isLocked = false
+    /// How far into the three-second hold the release key is, 0…1.
+    @Published private(set) var holdProgress: Double = 0
+    /// Seconds before the lock lifts on its own.
+    @Published private(set) var secondsLeft = Int(autoRelease)
+    /// Why the last attempt to lock was refused. Dropped when the tab is
+    /// entered: the permission may well have been granted in between, and a pane
+    /// still asking for it would be wrong.
+    @Published private(set) var refusal: Refusal?
+
+    /// Why a lock ended by itself, with no press behind it — and when.
+    ///
+    /// Kept apart from `refusal` because the two have opposite lifetimes, and one
+    /// setter cannot serve both. The panel is folded whenever the lock is on, so
+    /// by the time this is written the pane does not exist; entering the tab is
+    /// when it gets read, which is exactly when `refusal` has to be dropped.
+    @Published private var lastInterruption: (reason: Refusal, at: Date)?
+
+    /// The interruption while it is still news. Goes stale on its own, because
+    /// this describes an event, and a sentence about an event left on screen long
+    /// enough starts reading as a description of the present — "it is broken now"
+    /// instead of "it stopped a moment ago". Also dropped by the next press,
+    /// which answers it.
+    ///
+    /// A minute comes from that reading, not from any mechanism: there is no
+    /// technical moment at which the reason expires, only a point past which it
+    /// misinforms.
+    var interruption: Refusal? {
+        guard let lastInterruption,
+              Date().timeIntervalSince(lastInterruption.at) < Self.interruptionShelfLife
+        else { return nil }
+        return lastInterruption.reason
+    }
+
+    static let interruptionShelfLife: TimeInterval = 60
+
+    /// Never configurable. It is the one way out that does not depend on the
+    /// user, the app or the tap still working correctly.
+    static let autoRelease: TimeInterval = 60
+    /// Long enough that a cloth cannot do it by accident, short enough to hold
+    /// deliberately. Every text that names it reads it from here.
+    static let holdToRelease: TimeInterval = 2
+    /// How long the tap outlives the cover, waiting for the release key to come
+    /// up. A ceiling rather than a wait: a key that never reports its release —
+    /// stuck, or its keyUp lost with the app that had focus — must not hold the
+    /// keyboard hostage.
+    static let drainTimeout: TimeInterval = 2
+
+    /// Why a lock was refused, or why one ended before it was asked to.
+    enum Refusal {
+        case noAccess
+        case secureInput
+        case tapFailed
+        /// A previous tap is still being taken down. Unreachable by
+        /// construction — a drain is finished before this is checked — and it
+        /// exists so that the impossible case cannot be reported as a permission
+        /// problem, which is what it used to be folded into.
+        case busy
+    }
+
+    /// Physical keys, matched by code rather than character: a Cyrillic layout
+    /// prints something else entirely, and the way out must not depend on which
+    /// layout happened to be active when the cloth came out.
+    private enum Key {
+        static let escape: Int64 = 53
+        static let minus: Int64 = 27
+    }
+
+    private var tap: CFMachPort?
+    private var source: CFRunLoopSource?
+    private var ticker: Timer?
+    private var lockedAt: Date?
+    private var holdStartedAt: Date?
+    /// Which of the two release keys is being held, so the drain knows what to
+    /// wait for.
+    private var heldReleaseKey: Int64?
+    /// Key code the tap is still swallowing after the cover came off, if any.
+    private var drainKeyCode: Int64?
+    private var drainStartedAt: Date?
+
+    /// Whether the Accessibility permission is granted. Read every time rather
+    /// than cached: it is granted in System Settings, outside this app, and a
+    /// cached "no" would outlive the granting by a whole launch.
+    var hasAccess: Bool { AXIsProcessTrusted() }
+
+    /// Whether some app is holding secure event input — a password field, a
+    /// password manager, a terminal with secure keyboard entry.
+    ///
+    /// While it is held, keyboard events do not reach an event tap at all; that
+    /// is precisely what the mode is for. The tap would still install and the
+    /// cover would still go up, and every keystroke would land in whatever is in
+    /// front of it. A lock that only looks like one is the failure this class's
+    /// own comment calls worse than having no feature, so it is refused instead.
+    var isSecureInputActive: Bool { IsSecureEventInputEnabled() }
+
+    /// Raises the system's own permission dialog. Called from the pane's second
+    /// press, after the explanation — the first press is what asks for it.
+    func requestAccess() {
+        let prompt = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+        AXIsProcessTrustedWithOptions([prompt: true] as CFDictionary)
+    }
+
+    func openSettings() {
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        ) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    // MARK: - Lock
+
+    /// `nil` when the lock is on, otherwise why it is not.
+    @discardableResult
+    func lock() -> Refusal? {
+        guard !isLocked else { return nil }
+
+        // A press is the answer to whatever ended the last lock, so the
+        // explanation for it has been read and can go.
+        lastInterruption = nil
+
+        // A drain still owns a tap, and `isLocked` is already false by then, so
+        // it is not what the guard below can rely on: the meaningful state is
+        // whether a tap is installed, not whether the cover is up. Installing a
+        // second one would orphan the first — the run loop source keeps it
+        // alive, it keeps swallowing everything, and `release` only ever knows
+        // about the newest. That is input eaten until the process dies.
+        if drainKeyCode != nil { finishDrain() }
+        guard tap == nil else { return refuse(.busy) }
+
+        guard hasAccess else { return refuse(.noAccess) }
+        guard !isSecureInputActive else { return refuse(.secureInput) }
+
+        // Everything, not a hand-picked list: the point is that nothing gets
+        // through, and a list is a promise to have remembered every event type
+        // macOS has — including the ones it gains later.
+        let mask = ~CGEventMask(0)
+        guard let tap = CGEvent.tapCreate(
+            tap: .cghidEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: mask,
+            callback: { _, type, event, context in
+                guard let context else { return Unmanaged.passUnretained(event) }
+                let lock = Unmanaged<KeyboardLock>.fromOpaque(context).takeUnretainedValue()
+                return MainActor.assumeIsolated { lock.handle(type, event) }
+            },
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else { return refuse(.tapFailed) }
+
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+
+        self.tap = tap
+        self.source = source
+        lockedAt = Date()
+        holdStartedAt = nil
+        drainKeyCode = nil
+        drainStartedAt = nil
+        holdProgress = 0
+        secondsLeft = Int(Self.autoRelease)
+        refusal = nil
+        isLocked = true
+        startTicker()
+        return nil
+    }
+
+    /// Records the reason and hands it back, so every refusal is both returned
+    /// to the caller and visible to the pane.
+    private func refuse(_ reason: Refusal) -> Refusal {
+        refusal = reason
+        return reason
+    }
+
+    /// Called by the pane when the tab is entered. Drops only the press-time
+    /// reason: `interruption` is what the pane came to show, and clearing it here
+    /// would erase it one frame after it appeared.
+    func clearRefusal() {
+        refusal = nil
+    }
+
+    func unlock() {
+        guard isLocked || drainKeyCode != nil else { return }
+        drainKeyCode = nil
+        drainStartedAt = nil
+        isLocked = false
+        release()
+    }
+
+    /// Hold satisfied: the cover comes off now, the tap stays a moment longer to
+    /// swallow what is left of the held key.
+    ///
+    /// Auto-repeat is already in flight by the time the hold is satisfied,
+    /// and the events it produces do not stop with the lock — dropping the tap
+    /// here would send the tail of a held `-` into whatever document is in
+    /// front. Only key events are swallowed while draining, so the pointer is
+    /// live again the moment the screen comes back.
+    private func beginDrain(_ code: Int64) {
+        drainKeyCode = code
+        drainStartedAt = Date()
+        holdStartedAt = nil
+        holdProgress = 0
+        isLocked = false
+    }
+
+    /// Idempotent: the timeout in `tick` and the deferred call from the callback
+    /// can both arrive, and the second one must find nothing left to do.
+    private func finishDrain() {
+        guard drainStartedAt != nil else { return }
+        drainKeyCode = nil
+        drainStartedAt = nil
+        release()
+    }
+
+    private func release() {
+        ticker?.invalidate()
+        ticker = nil
+        if let tap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            if let source { CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes) }
+            CFMachPortInvalidate(tap)
+        }
+        tap = nil
+        source = nil
+        lockedAt = nil
+        holdStartedAt = nil
+        holdProgress = 0
+    }
+
+    // MARK: - Events
+
+    /// Returns `nil` for everything, which is what discards the event.
+    private func handle(_ type: CGEventType, _ event: CGEvent) -> Unmanaged<CGEvent>? {
+        // macOS switches a tap off if its callback ever takes too long, and says
+        // so through these two. Re-enabling is the difference between a lock
+        // that recovers and one that silently stopped locking.
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            return nil
+        }
+
+        let code = event.getIntegerValueField(.keyboardEventKeycode)
+
+        // Draining: the cover is already off, and the only thing still swallowed
+        // is the key that ended the lock, until it comes back up.
+        if let drainKeyCode {
+            let isKeyEvent = type == .keyDown || type == .keyUp || type == .flagsChanged
+            guard isKeyEvent else { return Unmanaged.passUnretained(event) }
+            if type == .keyUp, code == drainKeyCode {
+                // Off the callback, deliberately. Tearing the mach port down
+                // from inside its own callback — and then still returning to the
+                // tap machinery — is probably safe, since the run loop holds the
+                // source for the duration, but this is the ordinary way out of
+                // the lock and it should not rest on "probably". One extra pass
+                // of the run loop costs nothing here.
+                DispatchQueue.main.async { [weak self] in self?.finishDrain() }
+            }
+            return nil
+        }
+
+        let isReleaseKey = code == Key.escape || code == Key.minus
+        switch type {
+        case .keyDown where isReleaseKey:
+            // Auto-repeat fires keyDown over and over while the key is held, so
+            // the start is only recorded once — otherwise the hold would reset
+            // itself every repeat and never complete.
+            if holdStartedAt == nil {
+                holdStartedAt = Date()
+                heldReleaseKey = code
+            }
+        case .keyUp where isReleaseKey:
+            holdStartedAt = nil
+            heldReleaseKey = nil
+            holdProgress = 0
+        case .keyDown, .keyUp:
+            // Some other key: an accidental press under the cloth, and the one
+            // in-progress hold it must not credit. Modifiers arrive as
+            // `.flagsChanged` and deliberately do not reset it — a Shift caught
+            // by the cloth must not cost the way out.
+            holdStartedAt = nil
+            heldReleaseKey = nil
+            holdProgress = 0
+        default:
+            break
+        }
+        return nil
+    }
+
+    private func startTicker() {
+        // Never two of them: a second timer would tick forever, unreferenced.
+        ticker?.invalidate()
+        let timer = Timer(timeInterval: 1.0 / 20, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.tick() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        ticker = timer
+    }
+
+    private func tick() {
+        // The drain runs after the lock is off, so it is checked first — and it
+        // is the only thing this timer still has to do at that point.
+        if let drainStartedAt {
+            if Date().timeIntervalSince(drainStartedAt) >= Self.drainTimeout { finishDrain() }
+            return
+        }
+
+        guard isLocked, let lockedAt else { return }
+        let now = Date()
+
+        // Secure input can go up mid-wipe: a background app raising a password
+        // field is enough. From that moment the cover is a lie — keys reach the
+        // app in front, not the tap — so the lock ends rather than keeps a
+        // promise it no longer holds. The reason is recorded, or the cover would
+        // just disappear and read as a crash.
+        if isSecureInputActive {
+            unlock()
+            lastInterruption = (.secureInput, now)
+            return
+        }
+
+        if let holdStartedAt, let code = heldReleaseKey {
+            let held = now.timeIntervalSince(holdStartedAt)
+            holdProgress = min(1, held / Self.holdToRelease)
+            if held >= Self.holdToRelease {
+                beginDrain(code)
+                return
+            }
+        }
+
+        let elapsed = now.timeIntervalSince(lockedAt)
+        secondsLeft = max(0, Int((Self.autoRelease - elapsed).rounded(.up)))
+        if elapsed >= Self.autoRelease { unlock() }
+    }
+}

--- a/Sources/Cyclop/UI/NotchContentView.swift
+++ b/Sources/Cyclop/UI/NotchContentView.swift
@@ -98,6 +98,8 @@ struct NotchContentView: View {
             NotesCounter(notes: vm.notes)
         case .teleprompter:
             EmptyView()
+        case .utilities:
+            EmptyView()
         case .settings:
             EmptyView()
         }
@@ -165,6 +167,8 @@ struct NotchContentView: View {
             NotesPane(notes: vm.notes, privacy: vm.privacy, wantsKeyboard: $vm.wantsKeyboard)
         case .teleprompter:
             TeleprompterPane(prompter: vm.teleprompter, wantsKeyboard: $vm.wantsKeyboard)
+        case .utilities:
+            UtilitiesPane(lock: vm.keyboardLock)
         case .settings:
             SettingsPane(shelf: vm.shelf)
         }

--- a/Sources/Cyclop/UI/UtilitiesPane.swift
+++ b/Sources/Cyclop/UI/UtilitiesPane.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+/// One button across the whole pane. Deliberately not a list of one: a row
+/// layout built for items that do not exist yet would have to be guessed now and
+/// redone later anyway, and redoing the inside of a pane is cheap.
+struct UtilitiesPane: View {
+    @ObservedObject var lock: KeyboardLock
+
+    /// Read from the lock rather than kept here: one of the reasons — secure
+    /// input coming up mid-wipe — is raised by a timer with no press behind it,
+    /// and a copy in the view would never hear about it.
+    ///
+    /// An interruption wins: it describes a lock that was running a moment ago,
+    /// which is newer news than why an earlier press did not start one.
+    private var reason: KeyboardLock.Refusal? { lock.interruption ?? lock.refusal }
+    private var wasInterrupted: Bool { lock.interruption != nil }
+
+    var body: some View {
+        Button {
+            press()
+        } label: {
+            VStack(spacing: 8) {
+                Image(systemName: reason == nil ? "keyboard" : "hand.raised.fill")
+                    .font(.system(size: 26, weight: .light))
+                    .foregroundStyle(reason == nil ? .white : Color.white.opacity(0.75))
+
+                Text(title)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.white)
+
+                Text(caption)
+                    .font(.system(size: 10))
+                    .foregroundStyle(Theme.tertiary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 20)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Theme.surface)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .strokeBorder(Theme.hairline, lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .animation(Theme.contentAnimation, value: reason)
+        // Drops the press-time reason only: the permission may well have been
+        // granted in between, and the pane should not still be asking. What the
+        // pane came here to show — why a running lock ended — survives, because
+        // the panel is folded at the moment that is written and this return is
+        // the first chance to read it.
+        .onAppear { lock.clearRefusal() }
+    }
+
+    private var title: String {
+        if wasInterrupted { return localized("Lock ended early") }
+        switch lock.refusal {
+        case nil: return localized("Lock Keyboard")
+        case .noAccess: return localized("Allow in Settings")
+        case .secureInput: return localized("Input is protected")
+        case .tapFailed: return localized("Could not take over input")
+        case .busy: return localized("Still unlocking")
+        }
+    }
+
+    private var caption: String {
+        // A lock that ended is a different message from one that never started:
+        // nothing is being asked of the user, something is being reported.
+        if wasInterrupted {
+            return localized("An app turned on secure keyboard entry, so keys stopped\nreaching the lock. It ended instead of pretending")
+        }
+        switch lock.refusal {
+        case nil:
+            return localized(
+                "Wipe the keys and the screen. Hold Esc or − for %d s to\nunlock; it also unlocks by itself after a minute",
+                Int(KeyboardLock.holdToRelease)
+            )
+        case .noAccess:
+            return localized("Cyclop needs Accessibility to swallow keys and clicks.\nSystem Settings → Privacy & Security → Accessibility")
+        case .secureInput:
+            return localized("An app is holding secure keyboard entry — a password field,\na password manager, a terminal. Close it and press again")
+        case .tapFailed:
+            return localized("The system refused the event tap. Re-granting Accessibility\nusually fixes it — the permission is tied to the app's signature")
+        case .busy:
+            return localized("The previous lock is still being taken down.\nPress again in a moment")
+        }
+    }
+
+    private func press() {
+        // A second press on an explained refusal is the way to Settings: for a
+        // missing permission because that is where it is granted, and for a
+        // failed tap because a rebuilt app is a new signature to TCC and the
+        // stale entry has to be replaced by hand. The other two reasons pass
+        // through to another attempt — that is what they are waiting for.
+        if let reason, reason == .noAccess || reason == .tapFailed {
+            lock.openSettings()
+            return
+        }
+
+        // The system dialog comes with the explanation, not before it.
+        if lock.lock() == .noAccess { lock.requestAccess() }
+    }
+}


### PR DESCRIPTION
Вкладка, которая гасит клавиатуру и трекпад, пока протираешь их. Экран уходит в чёрное — на нём заодно видно разводы.

![Вкладка «Утилиты»](https://raw.githubusercontent.com/GeorgeSGN/cyclop/assets/docs/keyboard-lock.png)

Нужен Универсальный доступ: гасить события умеет только `CGEventTap` в режиме подавления. Спрашивается первым нажатием на кнопку, не при запуске, и сначала объяснением в панели.

Выходов три, независимых: удержание **Esc** или **`-`** две секунды, автоснятие через минуту, и смерть перехвата вместе с процессом. Пока какое-то приложение держит secure input, режим не запускается и говорит почему — иначе экран бы почернел, а нажатия уходили бы в активное окно.

Файлы: `KeyboardLock` — перехват и выходы, `CleaningOverlay` — чёрные окна на всех дисплеях, `UtilitiesPane` — кнопка. Вкладка встала в правый рельс перед настройками, локализация в обеих таблицах.

Проверено на двух дисплеях: `⌘Tab` не проходит, оба экрана накрыты, выход удержанием работает, отключение монитора под блокировкой её не снимает.
