### PR TITLE
Курсор над кнопками рядом с полями ввода перестаёт быть кареткой

### DIFF
--- a/Sources/Cyclop/UI/NotesPane.swift
+++ b/Sources/Cyclop/UI/NotesPane.swift
@@ -58,6 +58,7 @@ struct NotesPane: View {
                         .background(Circle().fill(Color.black.opacity(0.65)))
                 }
                 .buttonStyle(.plain)
+                .pointerStyle(.default)
                 .help(localized("Show"))
             }
         }
@@ -97,6 +98,7 @@ struct NotesPane: View {
                 .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
             }
             .buttonStyle(.plain)
+            .pointerStyle(.default)
 
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 3) {
@@ -286,6 +288,7 @@ private struct NoteRow: View {
                         .foregroundStyle(Theme.secondary)
                 }
                 .buttonStyle(.plain)
+                .pointerStyle(.default)
                 .help(localized("Delete"))
             }
         }

--- a/Sources/Cyclop/UI/SnippetsPane.swift
+++ b/Sources/Cyclop/UI/SnippetsPane.swift
@@ -56,6 +56,7 @@ struct SnippetsPane: View {
                         .foregroundStyle(Theme.secondary)
                 }
                 .buttonStyle(.plain)
+                .pointerStyle(.default)
             }
             Button { beginAdding() } label: {
                 Image(systemName: "plus")
@@ -63,6 +64,7 @@ struct SnippetsPane: View {
                     .foregroundStyle(Theme.secondary)
             }
             .buttonStyle(.plain)
+            .pointerStyle(.default)
             .help(localized("Add a snippet"))
         }
         .padding(.horizontal, 9)
@@ -141,6 +143,7 @@ struct SnippetsPane: View {
                     .foregroundStyle(draftText.isEmpty ? Theme.tertiary : Color.green)
             }
             .buttonStyle(.plain)
+            .pointerStyle(.default)
             .disabled(draftText.isEmpty)
 
             Button { cancelAdding() } label: {
@@ -149,6 +152,7 @@ struct SnippetsPane: View {
                     .foregroundStyle(Theme.secondary)
             }
             .buttonStyle(.plain)
+            .pointerStyle(.default)
         }
         .padding(.horizontal, 6)
         .frame(height: 28)
@@ -276,6 +280,7 @@ private struct SnippetRow: View {
                         .foregroundStyle(Theme.secondary)
                 }
                 .buttonStyle(.plain)
+                .pointerStyle(.default)
                 .help(localized("Delete"))
             }
         }

--- a/Sources/Cyclop/UI/TeleprompterPane.swift
+++ b/Sources/Cyclop/UI/TeleprompterPane.swift
@@ -131,6 +131,7 @@ struct TeleprompterPane: View {
                     wantsKeyboard = false
                 }
                 .buttonStyle(.plain)
+                .pointerStyle(.default)
                 .font(.system(size: 12, weight: .semibold, design: .rounded))
                 .foregroundStyle(prompter.script.isEmpty ? Theme.tertiary : .white)
                 .disabled(prompter.script.isEmpty)

--- a/Sources/Cyclop/UI/TranslatePane.swift
+++ b/Sources/Cyclop/UI/TranslatePane.swift
@@ -62,6 +62,7 @@ struct TranslatePane: View {
                         .foregroundStyle(Theme.secondary)
                 }
                 .buttonStyle(.plain)
+                .pointerStyle(.default)
             }
         } content: {
             // A `TextField(axis: .vertical)` grows to fit its text, and growing
@@ -126,6 +127,7 @@ struct TranslatePane: View {
                     Button("Retry") { translator.retry() }
                 }
                 .buttonStyle(.plain)
+                .pointerStyle(.default)
                 .font(.system(size: 10, weight: .medium))
                 .foregroundStyle(.white)
             }


### PR DESCRIPTION
Пока фокус стоит в текстовом поле, курсор над соседними кнопками остаётся кареткой: сфокусированное поле владеет указателем над своей областью, а кнопка со стилем `.plain` своего указателя не объявляет — подменять нечего.

Заметнее всего в заготовках: каретка в поиске, а над крестиком очистки, плюсом и кнопками формы добавления по-прежнему I-beam. То же в переводе, заметках и телесуфлёре.

Кнопки объявляют указатель сами. Одиннадцать штук в четырёх панелях — все, что стоят вплотную к полям.

Без фокуса в поле каретки на экране нет, поэтому и баг «то воспроизводится, то нет».
