### PR TITLE
Группы заготовок: одно имя, несколько значений

### DIFF
--- a/Sources/Cyclop/Services/SnippetStore.swift
+++ b/Sources/Cyclop/Services/SnippetStore.swift
@@ -14,11 +14,25 @@ struct Snippet: Identifiable, Codable, Equatable {
     /// correct while doing that, plus something hand-written rows would lack.
     /// A full duplicate, same name and same value, still collapses into one,
     /// which is the only case where collapsing is right.
-    var id: String { "\(label)\u{0}\(text)" }
+    var id: String { isGroup ? "group\u{0}\(label)" : "\(label)\u{0}\(text)" }
     /// Optional name. Without one the row shows the value itself, which is
     /// usually enough for an address or a phone number.
     var label: String = ""
     var text: String
+
+    /// Present only on a group, and then it holds the group's rows.
+    ///
+    /// Optional rather than merely empty, because "a group with nothing in it
+    /// yet" and "not a group" are different things, and an array cannot tell
+    /// them apart. In the file the key is simply there or not, which keeps the
+    /// hand-edited format honest: a row is what it always was, a group is a row
+    /// with `items`.
+    ///
+    /// One level deep. A group inside a group would have to be drawn inside a
+    /// panel five rows tall, and what it would be for nobody could say.
+    var items: [Snippet]?
+
+    var isGroup: Bool { items != nil }
 
     /// Guessed from the value, so a row is recognisable before it is read.
     var symbol: String {
@@ -30,11 +44,18 @@ struct Snippet: Identifiable, Codable, Equatable {
         return "text.alignleft"
     }
 
-    private enum CodingKeys: String, CodingKey { case label, text }
+    private enum CodingKeys: String, CodingKey { case label, text, items }
 
     init(label: String = "", text: String) {
         self.label = label
         self.text = text
+    }
+
+    /// A group: a name and the rows under it.
+    init(group label: String, items: [Snippet]) {
+        self.label = label
+        self.text = ""
+        self.items = items
     }
 
     /// `label` may be absent from the file — the documented format allows it,
@@ -45,7 +66,14 @@ struct Snippet: Identifiable, Codable, Equatable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         label = try container.decodeIfPresent(String.self, forKey: .label) ?? ""
-        text = try container.decode(String.self, forKey: .text)
+        // A group carries no value of its own, so `text` is required only for
+        // an ordinary row — demanding it of a group would make a perfectly
+        // reasonable hand-written file unreadable.
+        let nested = try container.decodeIfPresent([Snippet].self, forKey: .items)
+        text = try container.decodeIfPresent(String.self, forKey: .text) ?? ""
+        // Flattened on the way in, so depth cannot arrive from the file even if
+        // somebody nests by hand.
+        items = nested.map { $0.map { Snippet(label: $0.label, text: $0.text) } }
     }
 
     /// An unnamed snippet is written without the key rather than with an empty
@@ -54,7 +82,11 @@ struct Snippet: Identifiable, Codable, Equatable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         if !label.isEmpty { try container.encode(label, forKey: .label) }
-        try container.encode(text, forKey: .text)
+        if let items {
+            try container.encode(items, forKey: .items)
+        } else {
+            try container.encode(text, forKey: .text)
+        }
     }
 }
 
@@ -80,7 +112,13 @@ final class SnippetStore: ObservableObject {
     var filtered: [Snippet] {
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !needle.isEmpty else { return items }
-        return items.filter { $0.label.matches(needle) || $0.text.matches(needle) }
+        // A group matches by its own name or by anything under it: looking for
+        // "пароль" should find the group that holds one, not just rows called
+        // that at the top level.
+        return items.filter { item in
+            if item.label.matches(needle) || item.text.matches(needle) { return true }
+            return item.items?.contains { $0.label.matches(needle) || $0.text.matches(needle) } ?? false
+        }
     }
 
     /// `~/Library/Application Support/Cyclop/snippets.json`. A plain array of
@@ -138,6 +176,97 @@ final class SnippetStore: ObservableObject {
 
     func remove(_ snippet: Snippet) {
         items.removeAll { $0.id == snippet.id }
+        persist()
+    }
+
+    // MARK: - Groups
+    //
+    // Every one of these edits a row inside a group, so they share a shape:
+    // find the group, hand its rows to a closure, write the file. Spelled out
+    // once here rather than four times below.
+
+    /// Creates a group with its first row. A group is never made empty: an
+    /// empty one is a name with nothing under it, and the only thing to do with
+    /// it is fill it or delete it.
+    func addGroup(label: String, itemLabel: String, itemText: String) {
+        let value = itemText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty, !name.isEmpty else { return }
+        reload()
+        guard !fileBroken else {
+            NSLog("Cyclop: refusing to write over an unreadable snippets.json")
+            return
+        }
+        let group = Snippet(
+            group: name,
+            items: [Snippet(label: itemLabel.trimmingCharacters(in: .whitespacesAndNewlines), text: value)]
+        )
+        items.removeAll { $0.id == group.id }
+        items.insert(group, at: 0)
+        persist()
+    }
+
+    func addToGroup(_ group: Snippet, label: String, text: String) {
+        let value = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return }
+        let row = Snippet(label: label.trimmingCharacters(in: .whitespacesAndNewlines), text: value)
+        editGroup(group) { rows in
+            rows.removeAll { $0.id == row.id }
+            rows.append(row)
+        }
+    }
+
+    func update(_ row: Snippet, in group: Snippet, label: String, text: String) {
+        let value = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return }
+        let edited = Snippet(label: label.trimmingCharacters(in: .whitespacesAndNewlines), text: value)
+        guard edited != row else { return }
+        editGroup(group) { rows in
+            guard let index = rows.firstIndex(where: { $0.id == row.id }) else { return }
+            rows.removeAll { $0.id == edited.id && $0.id != row.id }
+            rows[min(index, rows.count - 1)] = edited
+        }
+    }
+
+    /// Removing the last row removes the group with it — see `addGroup`.
+    func remove(_ row: Snippet, from group: Snippet) {
+        editGroup(group) { rows in rows.removeAll { $0.id == row.id } }
+    }
+
+    func move(_ row: Snippet, to index: Int, in group: Snippet) {
+        editGroup(group) { rows in
+            guard let current = rows.firstIndex(where: { $0.id == row.id }) else { return }
+            let target = max(0, min(index, rows.count - 1))
+            guard target != current else { return }
+            rows.insert(rows.remove(at: current), at: target)
+        }
+    }
+
+    /// Renames a group, keeping its place and its rows.
+    func rename(_ group: Snippet, to label: String) {
+        let name = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty, name != group.label else { return }
+        // The namesake goes first, and only then is the place looked up: an
+        // index taken before the removal points into a list that has since
+        // shifted, and the write landed on the neighbour — renaming `target` to
+        // `prod` in [prod, target, x, y] overwrote `x` and left `target` as it
+        // was.
+        items.removeAll { $0.id == "group\u{0}\(name)" }
+        guard let index = items.firstIndex(where: { $0.id == group.id }),
+              let rows = items[index].items else { return }
+        items[index] = Snippet(group: name, items: rows)
+        persist()
+    }
+
+    private func editGroup(_ group: Snippet, _ change: (inout [Snippet]) -> Void) {
+        guard let index = items.firstIndex(where: { $0.id == group.id }),
+              var rows = items[index].items else { return }
+        change(&rows)
+        if rows.isEmpty {
+            items.remove(at: index)
+        } else {
+            items[index] = Snippet(group: items[index].label, items: rows)
+        }
         persist()
     }
 

--- a/Sources/Cyclop/Services/SnippetStore.swift
+++ b/Sources/Cyclop/Services/SnippetStore.swift
@@ -5,15 +5,15 @@ struct Snippet: Identifiable, Codable, Equatable {
     ///
     /// The name by itself made two snippets called the same thing one snippet:
     /// SwiftUI lists rows by identity, so the newer silently replaced the older
-    /// — and a password for production and one for staging, both called
-    /// `db-password`, is a perfectly reasonable pair to want.
+    /// — and a password and a staging password both called `nox-password` is a
+    /// perfectly reasonable pair to want.
     ///
-    /// A stored id would do the same job, but this file is meant to be opened
-    /// and edited by hand — hence the pretty printing and the unescaped slashes
-    /// — and technical ids in it would be one more thing to keep correct while
-    /// doing that, plus something hand-written rows would lack. A full
-    /// duplicate, same name and same value, still collapses into one, which is
-    /// the only case where collapsing is right.
+    /// A separate stored id would do the same job, but this file is meant to be
+    /// opened and edited by hand — hence the pretty printing and the unescaped
+    /// slashes — and technical ids in it would be one more thing to keep
+    /// correct while doing that, plus something hand-written rows would lack.
+    /// A full duplicate, same name and same value, still collapses into one,
+    /// which is the only case where collapsing is right.
     var id: String { "\(label)\u{0}\(text)" }
     /// Optional name. Without one the row shows the value itself, which is
     /// usually enough for an address or a phone number.
@@ -129,8 +129,8 @@ final class SnippetStore: ObservableObject {
         }
         // Only an exact duplicate — same name and same value — is dropped, and
         // it is dropped because two identical rows are indistinguishable in the
-        // list anyway. Snippets sharing a name but not a value are kept apart:
-        // see `Snippet.id`.
+        // list anyway. Two snippets sharing a name but not a value are kept
+        // apart: see `Snippet.id`.
         items.removeAll { $0.id == snippet.id }
         items.insert(snippet, at: 0)
         persist()
@@ -138,6 +138,53 @@ final class SnippetStore: ObservableObject {
 
     func remove(_ snippet: Snippet) {
         items.removeAll { $0.id == snippet.id }
+        persist()
+    }
+
+    /// Moves a snippet to another position and writes the new order.
+    ///
+    /// The order is the file's order, so dragging a row is a real edit and not
+    /// a view-only arrangement — the one people reach for is meant to end up on
+    /// top and stay there.
+    ///
+    /// Unlike `add` and `update`, this does not re-read the file first: a drag
+    /// is a continuous gesture, and re-reading mid-gesture would swap the list
+    /// out from under the row being dragged.
+    func move(_ snippet: Snippet, to index: Int) {
+        guard let current = items.firstIndex(where: { $0.id == snippet.id }) else { return }
+        let target = max(0, min(index, items.count - 1))
+        guard target != current else { return }
+        items.insert(items.remove(at: current), at: target)
+        persist()
+    }
+
+    /// Edits a snippet in place, keeping its position in the list.
+    ///
+    /// Not `remove` plus `add`: identity here is the name, so renaming makes a
+    /// different snippet as far as the list is concerned, and adding puts it on
+    /// top. A row edited in place would then jump to the front the moment its
+    /// name changed — while the person is still looking at it.
+    ///
+    /// An emptied value cancels the edit rather than deleting the row. Deleting
+    /// already has its own ✕, and losing a snippet to a stray ⌘A is a poor
+    /// trade for saving a press.
+    func update(_ snippet: Snippet, label: String, text: String) {
+        let value = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return }
+        let edited = Snippet(label: label.trimmingCharacters(in: .whitespacesAndNewlines), text: value)
+        guard edited != snippet else { return }
+
+        reload()
+        // A file that could not be read must not be written over.
+        guard !fileBroken else {
+            NSLog("Cyclop: refusing to write over an unreadable snippets.json")
+            return
+        }
+        guard let index = items.firstIndex(where: { $0.id == snippet.id }) else { return }
+        // An edit that turns this row into an exact copy of another one leaves
+        // a single row, for the same reason `add` does.
+        items.removeAll { $0.id == edited.id && $0.id != snippet.id }
+        items[min(index, items.count - 1)] = edited
         persist()
     }
 

--- a/Sources/Cyclop/Services/SnippetStore.swift
+++ b/Sources/Cyclop/Services/SnippetStore.swift
@@ -1,7 +1,20 @@
 import AppKit
 
 struct Snippet: Identifiable, Codable, Equatable {
-    var id: String { label.isEmpty ? text : label }
+    /// Name and value together, not the name alone.
+    ///
+    /// The name by itself made two snippets called the same thing one snippet:
+    /// SwiftUI lists rows by identity, so the newer silently replaced the older
+    /// — and a password for production and one for staging, both called
+    /// `db-password`, is a perfectly reasonable pair to want.
+    ///
+    /// A stored id would do the same job, but this file is meant to be opened
+    /// and edited by hand — hence the pretty printing and the unescaped slashes
+    /// — and technical ids in it would be one more thing to keep correct while
+    /// doing that, plus something hand-written rows would lack. A full
+    /// duplicate, same name and same value, still collapses into one, which is
+    /// the only case where collapsing is right.
+    var id: String { "\(label)\u{0}\(text)" }
     /// Optional name. Without one the row shows the value itself, which is
     /// usually enough for an address or a phone number.
     var label: String = ""
@@ -114,9 +127,10 @@ final class SnippetStore: ObservableObject {
             NSLog("Cyclop: refusing to write over an unreadable snippets.json")
             return
         }
-        // Identity is the name, or the value when there is no name. Two rows
-        // sharing one identity is not a duplicate to tidy up later — SwiftUI
-        // lists them by it, so the newer simply replaces the older.
+        // Only an exact duplicate — same name and same value — is dropped, and
+        // it is dropped because two identical rows are indistinguishable in the
+        // list anyway. Snippets sharing a name but not a value are kept apart:
+        // see `Snippet.id`.
         items.removeAll { $0.id == snippet.id }
         items.insert(snippet, at: 0)
         persist()

--- a/Sources/Cyclop/UI/SnippetsPane.swift
+++ b/Sources/Cyclop/UI/SnippetsPane.swift
@@ -220,9 +220,15 @@ struct SnippetsPane: View {
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 3) {
                     ForEach(snippets.filtered) { item in
-                        SnippetRow(item: item, snippets: snippets, privacy: privacy)
+                        SnippetRow(
+                            item: item,
+                            snippets: snippets,
+                            privacy: privacy,
+                            wantsKeyboard: $wantsKeyboard
+                        )
                     }
                 }
+                .animation(Theme.contentAnimation, value: snippets.items)
                 .padding(.bottom, 2)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -234,43 +240,130 @@ private struct SnippetRow: View {
     let item: Snippet
     @ObservedObject var snippets: SnippetStore
     @ObservedObject var privacy: PrivacyMode
+    /// Editing needs the keyboard, and the panel only takes it when asked.
+    @Binding var wantsKeyboard: Bool
     @State private var hovering = false
     @State private var justCopied = false
+    /// Set by a double click. While it is on, the row shows two fields instead
+    /// of its text, and the value is shown even under cover — editing what one
+    /// cannot read is not editing.
+    @State private var editing = false
+    @State private var draftLabel = ""
+    @State private var draftText = ""
+    @FocusState private var focus: Field?
 
-    private var hidden: Bool { privacy.hides(.snippets, "snippet.\(item.id)") }
+    private enum Field { case label, text }
+
+    private var hidden: Bool { privacy.hides(.snippets, "snippet.\(item.id)") && !editing }
+    /// Position in the stored list, not in the filtered one: moving is an edit
+    /// of the file's order, and the filter is only a way of looking at it.
+    private var index: Int { snippets.items.firstIndex(where: { $0.id == item.id }) ?? 0 }
+    private var isLast: Bool { index >= snippets.items.count - 1 }
 
     var body: some View {
-        HStack(spacing: 9) {
-            Image(systemName: justCopied ? "checkmark" : item.symbol)
+        HStack(spacing: editing ? 6 : 9) {
+            if !editing {
+                Image(systemName: justCopied ? "checkmark" : item.symbol)
                 .font(.system(size: 10, weight: .medium))
-                .foregroundStyle(justCopied ? Color.green : Theme.tertiary)
-                .frame(width: 14)
+                    .foregroundStyle(justCopied ? Color.green : Theme.tertiary)
+                    .frame(width: 14)
+            }
             // The name stays legible while the value is covered: the row has to
             // say what it copies, or a list of covered rows is a list of
             // identical rows. An unnamed snippet shows its value as its name,
             // so covering the value covers the whole row — which is right,
             // since there is nothing else in it.
-            if !item.label.isEmpty {
-                Text(item.label)
+            if editing {
+                // The same two surfaces as the add form above: a row being
+                // edited and a row being created are the same act, and looking
+                // alike is the whole of saying so. Bare fields inside the row
+                // read as text that had lost its alignment.
+                TextField(localized("Name"), text: $draftLabel)
+                    .textFieldStyle(.plain)
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.white)
-                    .lineLimit(1)
-                    .layoutPriority(1)
+                    .tint(Theme.secondary)
+                    .padding(.horizontal, 7)
+                    .frame(width: 104, height: 20)
+                    .background(
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(Theme.surface)
+                    )
+                    .focused($focus, equals: .label)
+                    .onSubmit { commit() }
+
+                TextField(localized("Text"), text: $draftText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white)
+                    .tint(Theme.secondary)
+                    .padding(.horizontal, 7)
+                    .frame(height: 20)
+                    .background(
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(Theme.surface)
+                    )
+                    .focused($focus, equals: .text)
+                    .onSubmit { commit() }
+
+                Button { commit() } label: {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(draftText.isEmpty ? Theme.tertiary : Color.green)
+                }
+                .buttonStyle(.plain)
+                .disabled(draftText.isEmpty)
+
+                Button { cancel() } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(Theme.secondary)
+                }
+                .buttonStyle(.plain)
+            } else {
+                if !item.label.isEmpty {
+                    Text(item.label)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .layoutPriority(1)
+                }
+                SpoilerText(
+                    text: item.text.replacingOccurrences(of: "\n", with: " "),
+                    hidden: hidden,
+                    color: item.label.isEmpty ? .white : Theme.secondary,
+                    seed: UInt64(bitPattern: Int64(item.id.hashValue))
+                )
             }
-            SpoilerText(
-                text: item.text.replacingOccurrences(of: "\n", with: " "),
-                hidden: hidden,
-                color: item.label.isEmpty ? .white : Theme.secondary,
-                seed: UInt64(bitPattern: Int64(item.id.hashValue))
-            )
             Spacer(minLength: 6)
             // Only under the pointer: a row of crosses would compete with the
             // snippets themselves for a glance.
-            if hovering {
+            if hovering, !editing {
                 if privacy.covers(.snippets) {
                     RevealEye(hidden: hidden) { privacy.toggle("snippet.\(item.id)") }
                 }
-                Button { snippets.remove(item) } label: {
+                // Order is priority: the one reached for most often belongs on
+                // top. Arrows rather than dragging — the list is a few rows
+                // long, and a drag here brought more edge cases than movement:
+                // where a row lands under a live filter, what happens past the
+                // ends, and how it coexists with the taps that copy and edit.
+                Button { move(to: index - 1) } label: {
+                    Image(systemName: "chevron.up")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(index == 0 ? Theme.tertiary : Theme.secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(index == 0)
+
+                Button { move(to: index + 1) } label: {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(isLast ? Theme.tertiary : Theme.secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(isLast)
+
+                Button { remove() } label: {
                     Image(systemName: "xmark")
                         .font(.system(size: 9, weight: .semibold))
                         .foregroundStyle(Theme.secondary)
@@ -279,14 +372,19 @@ private struct SnippetRow: View {
                 .help(localized("Delete"))
             }
         }
-        .padding(.horizontal, 9)
-        .frame(height: 26)
+        .padding(.horizontal, editing ? 6 : 9)
+        .frame(height: editing ? 28 : 26)
         .background(
             RoundedRectangle(cornerRadius: 7, style: .continuous)
-                .fill(hovering ? Theme.surfaceHover : Theme.surface)
+                .fill(editing || hovering ? Theme.surfaceHover : Theme.surface)
         )
         .contentShape(Rectangle())
         .onHover { hovering = $0 }
+        // Double first: SwiftUI hands a tap to the last matching gesture, and
+        // with the single one declared first a double click would only ever
+        // copy. The first click of a double still copies — harmless, and the
+        // alternative is delaying every single click to see if a second lands.
+        .onTapGesture(count: 2) { beginEditing() }
         .onTapGesture {
             snippets.copy(item)
             // Emptying the search lets go of the panel: nothing is being typed
@@ -296,5 +394,43 @@ private struct SnippetRow: View {
         }
         .animation(Theme.contentAnimation, value: hovering)
         .animation(Theme.contentAnimation, value: justCopied)
+        .animation(Theme.contentAnimation, value: editing)
+        .onExitCommand { cancel() }
+        // Losing the focus saves: clicking away from a row one has just edited
+        // is not a way of throwing the edit out — Esc is.
+        .onChange(of: focus) { _, now in
+            if editing, now == nil { commit() }
+        }
+        // The panel folds by itself when the pointer leaves, and the row goes
+        // with it. Whatever was typed by then has to survive that.
+        .onDisappear { if editing { commit() } }
+    }
+
+    private func beginEditing() {
+        draftLabel = item.label
+        draftText = item.text
+        editing = true
+        focus = item.label.isEmpty ? .text : .label
+        wantsKeyboard = true
+    }
+
+    private func move(to index: Int) {
+        snippets.move(item, to: index)
+    }
+
+    private func remove() {
+        snippets.remove(item)
+    }
+
+    private func cancel() {
+        editing = false
+        focus = nil
+    }
+
+    private func commit() {
+        guard editing else { return }
+        editing = false
+        focus = nil
+        snippets.update(item, label: draftLabel, text: draftText)
     }
 }

--- a/Sources/Cyclop/UI/SnippetsPane.swift
+++ b/Sources/Cyclop/UI/SnippetsPane.swift
@@ -8,12 +8,15 @@ struct SnippetsPane: View {
 
     /// Which field has the caret. One state for all three, because only one of
     /// them can be typed into at a time and the pane switches between them.
-    private enum Field { case search, label, text }
+    private enum Field { case search, group, label, text }
 
     @FocusState private var focused: Field?
     @State private var isAdding = false
     @State private var draftLabel = ""
     @State private var draftText = ""
+    /// Set while the form is making a group rather than a plain snippet: the
+    /// group needs a name of its own, above the first row's.
+    @State private var draftGroup: String?
 
     var body: some View {
         VStack(spacing: 6) {
@@ -57,6 +60,14 @@ struct SnippetsPane: View {
                 }
                 .buttonStyle(.plain)
             }
+            Button { beginAdding(group: true) } label: {
+                Image(systemName: "folder.badge.plus")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Theme.secondary)
+            }
+            .buttonStyle(.plain)
+            .help(localized("Add a group"))
+
             Button { beginAdding() } label: {
                 Image(systemName: "plus")
                     .font(.system(size: 11, weight: .semibold))
@@ -104,6 +115,24 @@ struct SnippetsPane: View {
     /// the list.
     private var editor: some View {
         HStack(spacing: 6) {
+            if draftGroup != nil {
+                TextField(
+                    localized("Group"),
+                    text: Binding(get: { draftGroup ?? "" }, set: { draftGroup = $0 })
+                )
+                .textFieldStyle(.plain)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.white)
+                .tint(Theme.secondary)
+                .padding(.horizontal, 7)
+                .frame(width: 92, height: 20)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(Theme.surface)
+                )
+                .focused($focused, equals: .group)
+                .onSubmit { commit() }
+            }
             // Each field on its own surface. A hairline between them read as a
             // caret sitting in the wrong place — exactly where one is expected,
             // which is the worst place for something that only looks like one.
@@ -163,7 +192,7 @@ struct SnippetsPane: View {
         //
         // The value is the part that cannot be left out, so the caret starts
         // there; the name is a step back for those who want one.
-        .onAppear { focused = .text }
+        .onAppear { focused = draftGroup == nil ? .text : .group }
         // Escape leaves the draft rather than the tab. Caught on the row so it
         // works from either field.
         .onKeyPress(.escape) {
@@ -172,7 +201,8 @@ struct SnippetsPane: View {
         }
     }
 
-    private func beginAdding() {
+    private func beginAdding(group: Bool = false) {
+        draftGroup = group ? "" : nil
         draftLabel = ""
         draftText = ""
         // The search field goes away with the row, but the filter behind it
@@ -186,12 +216,22 @@ struct SnippetsPane: View {
 
     private func cancelAdding() {
         isAdding = false
+        draftGroup = nil
         draftLabel = ""
         draftText = ""
     }
 
     private func commit() {
         guard !draftText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        if let name = draftGroup {
+            // A group is made with its first row and then closes the form: the
+            // rest is added from the group's own plus, where the name is
+            // already decided and does not need retyping.
+            guard !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            snippets.addGroup(label: name, itemLabel: draftLabel, itemText: draftText)
+            cancelAdding()
+            return
+        }
         snippets.add(label: draftLabel, text: draftText)
         // Straight into another one: adding snippets comes in runs, and the
         // list underneath already shows what has landed.
@@ -220,12 +260,21 @@ struct SnippetsPane: View {
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 3) {
                     ForEach(snippets.filtered) { item in
-                        SnippetRow(
-                            item: item,
-                            snippets: snippets,
-                            privacy: privacy,
-                            wantsKeyboard: $wantsKeyboard
-                        )
+                        if item.isGroup {
+                            SnippetGroup(
+                                group: item,
+                                snippets: snippets,
+                                privacy: privacy,
+                                wantsKeyboard: $wantsKeyboard
+                            )
+                        } else {
+                            SnippetRow(
+                                item: item,
+                                snippets: snippets,
+                                privacy: privacy,
+                                wantsKeyboard: $wantsKeyboard
+                            )
+                        }
                     }
                 }
                 .animation(Theme.contentAnimation, value: snippets.items)
@@ -238,6 +287,9 @@ struct SnippetsPane: View {
 
 private struct SnippetRow: View {
     let item: Snippet
+    /// The group this row belongs to, if it is inside one. Every edit goes
+    /// through it, so the row itself does not have to know two sets of methods.
+    var group: Snippet?
     @ObservedObject var snippets: SnippetStore
     @ObservedObject var privacy: PrivacyMode
     /// Editing needs the keyboard, and the panel only takes it when asked.
@@ -254,11 +306,24 @@ private struct SnippetRow: View {
 
     private enum Field { case label, text }
 
-    private var hidden: Bool { privacy.hides(.snippets, "snippet.\(item.id)") && !editing }
+    private var key: String { "snippet.\(group.map { "\($0.id)/" } ?? "")\(item.id)" }
+    private var hidden: Bool { privacy.hides(.snippets, key) && !editing }
     /// Position in the stored list, not in the filtered one: moving is an edit
     /// of the file's order, and the filter is only a way of looking at it.
-    private var index: Int { snippets.items.firstIndex(where: { $0.id == item.id }) ?? 0 }
-    private var isLast: Bool { index >= snippets.items.count - 1 }
+    /// A row on its own sits on a lit surface against the black panel. A row
+    /// inside a group sits on that same surface, so lighting it again would
+    /// make two barely different greys — the group and its contents blurred
+    /// into one patch. Inside, the rows are sunk instead.
+    private var fill: Color {
+        guard group != nil else {
+            return editing || hovering ? Theme.surfaceHover : Theme.surface
+        }
+        return editing || hovering ? Color.black.opacity(0.18) : Color.black.opacity(0.32)
+    }
+
+    private var siblings: [Snippet] { group?.items ?? snippets.items }
+    private var index: Int { siblings.firstIndex(where: { $0.id == item.id }) ?? 0 }
+    private var isLast: Bool { index >= siblings.count - 1 }
 
     var body: some View {
         HStack(spacing: editing ? 6 : 9) {
@@ -340,7 +405,7 @@ private struct SnippetRow: View {
             // snippets themselves for a glance.
             if hovering, !editing {
                 if privacy.covers(.snippets) {
-                    RevealEye(hidden: hidden) { privacy.toggle("snippet.\(item.id)") }
+                    RevealEye(hidden: hidden) { privacy.toggle(key) }
                 }
                 // Order is priority: the one reached for most often belongs on
                 // top. Arrows rather than dragging — the list is a few rows
@@ -376,7 +441,7 @@ private struct SnippetRow: View {
         .frame(height: editing ? 28 : 26)
         .background(
             RoundedRectangle(cornerRadius: 7, style: .continuous)
-                .fill(editing || hovering ? Theme.surfaceHover : Theme.surface)
+                .fill(fill)
         )
         .contentShape(Rectangle())
         .onHover { hovering = $0 }
@@ -415,11 +480,19 @@ private struct SnippetRow: View {
     }
 
     private func move(to index: Int) {
-        snippets.move(item, to: index)
+        if let group {
+            snippets.move(item, to: index, in: group)
+        } else {
+            snippets.move(item, to: index)
+        }
     }
 
     private func remove() {
-        snippets.remove(item)
+        if let group {
+            snippets.remove(item, from: group)
+        } else {
+            snippets.remove(item)
+        }
     }
 
     private func cancel() {
@@ -431,6 +504,234 @@ private struct SnippetRow: View {
         guard editing else { return }
         editing = false
         focus = nil
-        snippets.update(item, label: draftLabel, text: draftText)
+        if let group {
+            snippets.update(item, in: group, label: draftLabel, text: draftText)
+        } else {
+            snippets.update(item, label: draftLabel, text: draftText)
+        }
+    }
+}
+
+/// A group: one name with several values under it, all of them on view.
+///
+/// Not a folder that opens. The pair this exists for is a login and its
+/// password, and hiding one behind a click would undo the point of keeping them
+/// together. Only past a few rows does it fold, and then to keep the panel —
+/// five rows tall — from being spent on a single group.
+private struct SnippetGroup: View {
+    let group: Snippet
+    @ObservedObject var snippets: SnippetStore
+    @ObservedObject var privacy: PrivacyMode
+    @Binding var wantsKeyboard: Bool
+
+    @State private var hovering = false
+    @State private var collapsed = false
+    @State private var adding = false
+    @State private var draftLabel = ""
+    @State private var draftText = ""
+    @State private var renaming = false
+    @State private var draftName = ""
+    @FocusState private var focus: Field?
+
+    private enum Field { case name, label, text }
+
+    /// Rows are folded away only when there are enough of them to be worth it.
+    private static let foldsPast = 3
+
+    private var rows: [Snippet] { group.items ?? [] }
+    private var foldable: Bool { rows.count > Self.foldsPast }
+    private var index: Int { snippets.items.firstIndex(where: { $0.id == group.id }) ?? 0 }
+    private var isLast: Bool { index >= snippets.items.count - 1 }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            header
+            if !collapsed {
+                ForEach(rows) { row in
+                    SnippetRow(
+                        item: row,
+                        group: group,
+                        snippets: snippets,
+                        privacy: privacy,
+                        wantsKeyboard: $wantsKeyboard
+                    )
+                }
+                if adding { draft }
+            }
+        }
+        .padding(4)
+        .background(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .fill(Theme.surface)
+        )
+        .onHover { hovering = $0 }
+        .animation(Theme.contentAnimation, value: collapsed)
+        .animation(Theme.contentAnimation, value: adding)
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            if foldable {
+                Button { collapsed.toggle() } label: {
+                    Image(systemName: collapsed ? "chevron.right" : "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(Theme.tertiary)
+                }
+                .buttonStyle(.plain)
+            }
+
+            if renaming {
+                TextField(localized("Name"), text: $draftName)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .tint(Theme.secondary)
+                    .padding(.horizontal, 6)
+                    .frame(height: 18)
+                    .background(
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(Theme.surface)
+                    )
+                    .focused($focus, equals: .name)
+                    .onSubmit { commitRename() }
+            } else {
+                // The name stays readable whatever is covered below it: a list
+                // of covered groups must still say which is which.
+                Text(group.label.uppercased())
+                    .font(.system(size: 9, weight: .semibold))
+                    .tracking(0.6)
+                    .foregroundStyle(Theme.tertiary)
+                    .lineLimit(1)
+            }
+
+            if collapsed {
+                Text("\(rows.count)")
+                    .font(.system(size: 9, weight: .medium).monospacedDigit())
+                    .foregroundStyle(Theme.tertiary)
+            }
+
+            Spacer(minLength: 4)
+
+            if hovering, !renaming {
+                Button { beginAdding() } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Theme.secondary)
+                }
+                .buttonStyle(.plain)
+                .help(localized("Add a snippet"))
+
+                Button { snippets.move(group, to: index - 1) } label: {
+                    Image(systemName: "chevron.up")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(index == 0 ? Theme.tertiary : Theme.secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(index == 0)
+
+                Button { snippets.move(group, to: index + 1) } label: {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(isLast ? Theme.tertiary : Theme.secondary)
+                }
+                .buttonStyle(.plain)
+                .disabled(isLast)
+            }
+        }
+        .padding(.horizontal, 5)
+        .frame(height: 16)
+        .contentShape(Rectangle())
+        .onTapGesture(count: 2) { beginRenaming() }
+    }
+
+    /// The same pair of fields as everywhere else, so adding to a group looks
+    /// like adding anywhere.
+    private var draft: some View {
+        HStack(spacing: 6) {
+            TextField(localized("Name"), text: $draftLabel)
+                .textFieldStyle(.plain)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.white)
+                .tint(Theme.secondary)
+                .padding(.horizontal, 7)
+                .frame(width: 104, height: 20)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(Theme.surface)
+                )
+                .focused($focus, equals: .label)
+                .onSubmit { commitAdding() }
+
+            TextField(localized("Text"), text: $draftText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 11))
+                .foregroundStyle(.white)
+                .tint(Theme.secondary)
+                .padding(.horizontal, 7)
+                .frame(height: 20)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(Theme.surface)
+                )
+                .focused($focus, equals: .text)
+                .onSubmit { commitAdding() }
+
+            Button { commitAdding() } label: {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(draftText.isEmpty ? Theme.tertiary : Color.green)
+            }
+            .buttonStyle(.plain)
+            .disabled(draftText.isEmpty)
+
+            Button { cancelAdding() } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Theme.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 6)
+        .frame(height: 26)
+        .background(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(Theme.surfaceHover)
+        )
+        .onExitCommand { cancelAdding() }
+    }
+
+    private func beginAdding() {
+        draftLabel = ""
+        draftText = ""
+        collapsed = false
+        adding = true
+        wantsKeyboard = true
+        focus = .text
+    }
+
+    private func commitAdding() {
+        guard !draftText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        snippets.addToGroup(group, label: draftLabel, text: draftText)
+        cancelAdding()
+    }
+
+    private func cancelAdding() {
+        adding = false
+        draftLabel = ""
+        draftText = ""
+        focus = nil
+    }
+
+    private func beginRenaming() {
+        draftName = group.label
+        renaming = true
+        wantsKeyboard = true
+        focus = .name
+    }
+
+    private func commitRename() {
+        renaming = false
+        focus = nil
+        snippets.rename(group, to: draftName)
     }
 }


### PR DESCRIPTION
Логин и пароль от одного стенда — две отдельные заготовки, и в списке они расходятся, стоит добавить что-нибудь между ними. Группа держит их вместе под одним именем.

![Группа заготовок](https://raw.githubusercontent.com/GeorgeSGN/cyclop/assets/docs/snippet-groups.png)

Это не папка, которая открывается. Всё, что в группе, видно сразу: пара «логин — пароль» затем и нужна, чтобы взять её целиком, а не разворачивать по клику. Сворачивание появляется, только когда строк больше трёх — иначе одна группа съест панель, в которой помещается пять.

Каждая строка внутри копируется своим кликом, правится двойным, удаляется крестиком и двигается стрелками внутри группы. Заголовок двигает группу целиком, двойной клик по нему переименовывает, плюс по наведению добавляет строку. Удаление последней строки убирает и группу: имя без содержимого ничего не значит.

Скрытие работает по строкам, а не по группе — пароль прячется отдельно от логина, и раскрыть один можно, не раскрывая второй. Имя группы видно всегда, иначе список закрытых групп превращается в список одинаковых пятен.

Группа создаётся сразу с первой строкой — пустых групп не бывает.

## Файл

Формат остаётся тем же, каким его читают и правят руками: группа — это запись с `items` вместо `text`.

```json
[
  { "label": "почта", "text": "george@example.com" },
  { "label": "prod", "items": [
      { "label": "login", "text": "..." },
      { "label": "password", "text": "..." }
  ]}
]
```

Запись без `items` — обычная заготовка, так что существующие файлы читаются как есть и переносить ничего не надо. Вложенность одна: если написать глубже руками, лишнее расплющится при чтении — рисовать группу внутри группы в панели высотой в пять строк не во что.

Поиск заглядывает внутрь групп: «password» находит группу, которая его держит, а не только строки верхнего уровня.

Идут поверх #47 и #49 — правка строк внутри группы это та же правка на месте, что и снаружи. Если те будут смержены, здесь останется один коммит.
