### PR TITLE
Скрытие включается прямо во вкладке, а не только из меню

### DIFF
--- a/Sources/Cyclop/UI/ClipboardPane.swift
+++ b/Sources/Cyclop/UI/ClipboardPane.swift
@@ -27,8 +27,9 @@ struct ClipboardPane: View {
     }
 
     private var footer: some View {
-        HStack {
+        HStack(spacing: 10) {
             Spacer()
+            PrivacySwitch(privacy: privacy, section: .clipboard)
             Button("Clear") { clipboard.clear() }
                 .buttonStyle(.plain)
                 .font(.system(size: 10, weight: .medium))

--- a/Sources/Cyclop/UI/SnippetsPane.swift
+++ b/Sources/Cyclop/UI/SnippetsPane.swift
@@ -57,6 +57,7 @@ struct SnippetsPane: View {
                 }
                 .buttonStyle(.plain)
             }
+            PrivacySwitch(privacy: privacy, section: .snippets)
             Button { beginAdding() } label: {
                 Image(systemName: "plus")
                     .font(.system(size: 11, weight: .semibold))

--- a/Sources/Cyclop/UI/SpoilerField.swift
+++ b/Sources/Cyclop/UI/SpoilerField.swift
@@ -156,3 +156,36 @@ struct RevealEye: View {
         .help(hidden ? Text(localized("Show")) : Text(localized("Hide")))
     }
 }
+
+/// Turns covering on or off for one section, from inside the tab it covers.
+///
+/// The menu bar keeps the switch that decides everything at once, in a hurry,
+/// with the camera already running. This is the other half: while the tab is
+/// open anyway, reaching for the menu to cover the very thing on screen is a
+/// trip through two menus for a decision that belongs where it applies.
+///
+/// Inside the tab rather than in the panel header, because that strip lies
+/// directly on the menu bar, where utilities like Ice watch for clicks with a
+/// global monitor and fire on anything interactive placed there.
+struct PrivacySwitch: View {
+    @ObservedObject var privacy: PrivacyMode
+    let section: PrivacyMode.Section
+
+    private var covering: Bool { privacy.covers(section) }
+
+    var body: some View {
+        Button {
+            privacy.setCovering(section, !covering)
+        } label: {
+            Image(systemName: covering ? "eye.slash.fill" : "eye")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(covering ? Color.white.opacity(0.8) : Theme.secondary)
+        }
+        .buttonStyle(.plain)
+        // The switch in the snippets tab stands next to the search field, and a
+        // focused field owns the I-beam over its own area: without a pointer of
+        // its own the button would keep the caret while being clickable.
+        .pointerStyle(.default)
+        .help(covering ? localized("Show") : localized("Hide"))
+    }
+}


### PR DESCRIPTION
Скрытие сейчас включается только из меню-бара. Это правильное место для «закрыть всё разом», когда камера уже пишет, — но когда вкладка и так открыта, накрыть именно её означает путь через меню и подменю ради решения, которое относится к тому, что перед глазами.

Кнопка добавлена внутрь вкладок буфера и заготовок: у буфера — в нижнюю строку рядом с «Очистить», у заготовок — в строку поиска рядом с плюсом. Открытый глаз означает «видно», перечёркнутый — «закрыто».

![Переключатель во вкладке заготовок](https://raw.githubusercontent.com/GeorgeSGN/cyclop/assets/docs/snippet-groups.png)

Меню-бар не тронут: он по-прежнему решает за все разделы сразу, и состояние у них общее — включённое кнопкой видно в меню и наоборот.

В календарь и заметки не добавлял: там шапки заняты, и очевидного места для кнопки нет. Если оно найдётся, `PrivacySwitch` работает с любым разделом.

Кнопка стоит внутри вкладки, а не в шапке панели, намеренно: шапка лежит прямо на меню-баре, где утилиты вроде Ice ловят клики глобальным монитором — интерактив там срабатывал бы заодно и у них.
