### PR TITLE
Вкладка конвертера валют

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "Snippets" = "Snippets";
 "Calendar" = "Calendar";
 "Translate" = "Translate";
+"Currency" = "Currency";
 "Settings" = "Settings";
 
 /* Menu bar */
@@ -64,6 +65,11 @@
 "Retry" = "Retry";
 "The %@ → %@ language pack is not installed." = "The %@ → %@ language pack is not installed.";
 "macOS does not translate this pair of languages." = "macOS does not translate this pair of languages.";
+
+/* Currency */
+"Search currency" = "Search currency";
+"Swap currencies" = "Swap currencies";
+"No currencies match" = "No currencies match";
 
 /* Calendar */
 "Join" = "Join";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -8,6 +8,7 @@
 "Snippets" = "Заготовки";
 "Calendar" = "Календарь";
 "Translate" = "Перевод";
+"Currency" = "Валюта";
 "Settings" = "Настройки";
 
 /* Меню-бар */
@@ -63,6 +64,11 @@
 "Retry" = "Повторить";
 "The %@ → %@ language pack is not installed." = "Не скачан языковой пакет %@ → %@.";
 "macOS does not translate this pair of languages." = "macOS не переводит эту пару языков.";
+
+/* Валюта */
+"Search currency" = "Поиск валюты";
+"Swap currencies" = "Поменять валюты";
+"No currencies match" = "Ничего не найдено";
 
 /* Календарь */
 "Join" = "Подключиться";

--- a/Sources/Cyclop/Model/NotchViewModel.swift
+++ b/Sources/Cyclop/Model/NotchViewModel.swift
@@ -4,7 +4,7 @@ import Combine
 @MainActor
 final class NotchViewModel: ObservableObject {
     enum Tab: String, CaseIterable, Identifiable {
-        case media, shelf, clipboard, snippets, calendar, translate, notes, teleprompter, settings
+        case media, shelf, clipboard, snippets, calendar, translate, currency, notes, teleprompter, settings
         var id: String { rawValue }
 
         var symbol: String {
@@ -15,6 +15,7 @@ final class NotchViewModel: ObservableObject {
             case .snippets: return "pin.fill"
             case .calendar: return "calendar"
             case .translate: return "translate"
+            case .currency: return "dollarsign.circle"
             case .notes: return "note.text"
             case .teleprompter: return "text.viewfinder"
             case .settings: return "gearshape.fill"
@@ -29,6 +30,7 @@ final class NotchViewModel: ObservableObject {
             case .snippets: return localized("Snippets")
             case .calendar: return localized("Calendar")
             case .translate: return localized("Translate")
+            case .currency: return localized("Currency")
             case .notes: return localized("Notes")
             case .teleprompter: return localized("Teleprompter")
             case .settings: return localized("Settings")
@@ -37,7 +39,9 @@ final class NotchViewModel: ObservableObject {
 
         /// Tabs with a field in them. Landing on one hands it the keyboard, so
         /// that arriving and typing is a single move.
-        var needsKeyboard: Bool { self == .translate || self == .snippets || self == .notes }
+        var needsKeyboard: Bool {
+            self == .translate || self == .currency || self == .snippets || self == .notes
+        }
 
         /// Every tab can be taken off the rail except the one the switches
         /// live on: with Settings gone there would be no way back.
@@ -48,12 +52,13 @@ final class NotchViewModel: ObservableObject {
         /// #27), so a seventh icon would not overflow the panel, but it would
         /// shrink every icon on the rail to make room, which is the same
         /// objection in a quieter voice. Growth continues in a second column
-        /// on the right, which the scratch notes open. Settings joins that
-        /// column rather than the content rail: it is not something to hover
-        /// past on the way to a track or a calendar, so it sits last,
-        /// furthest from the tabs people actually rest on.
+        /// on the right: currency sits first there, right after translate,
+        /// then the scratch notes. Settings joins that column rather than the
+        /// content rail: it is not something to hover past on the way to a
+        /// track or a calendar, so it sits last, furthest from the tabs
+        /// people actually rest on.
         static let leftRail: [Tab] = [.media, .shelf, .clipboard, .snippets, .calendar, .translate]
-        static let rightRail: [Tab] = [.notes, .teleprompter, .settings]
+        static let rightRail: [Tab] = [.currency, .notes, .teleprompter, .settings]
     }
 
     /// What every screen's panel adds up to, kept by `NotchController`: this
@@ -109,8 +114,10 @@ final class NotchViewModel: ObservableObject {
         UserDefaults.standard.set(hiddenTabs.map(\.rawValue).sorted(), forKey: Self.hiddenTabsKey)
     }
 
-    /// What a tab keeps running while nobody is looking at it. Only four have
-    /// anything: the rest are a file read on the way in, or a field.
+    /// What a tab keeps running while nobody is looking at it. Only a few have
+    /// anything: the rest are a file read on the way in, or a field. Currency
+    /// is one of them — its timer must not keep asking the network after the
+    /// icon has left the rail.
     private func startBackground(of target: Tab) {
         switch target {
         case .media:
@@ -127,6 +134,8 @@ final class NotchViewModel: ObservableObject {
             // Off until the user grants a folder through `requestAccess`;
             // this only re-arms a watch already approved on a previous launch.
             screenshotFolder.resumeIfEnabled()
+        case .currency:
+            currencies.start()
         case .snippets, .translate, .notes, .teleprompter, .settings:
             break
         }
@@ -138,6 +147,7 @@ final class NotchViewModel: ObservableObject {
         case .clipboard: clipboard.stop()
         case .calendar: calendar.stop()
         case .shelf: screenshotFolder.stop()
+        case .currency: currencies.stop()
         case .snippets, .translate, .notes, .teleprompter, .settings: break
         }
     }
@@ -180,6 +190,9 @@ final class NotchViewModel: ObservableObject {
             // prompt. It is asked here, with the shelf on screen, rather than
             // at launch with nothing to explain it.
             if tab == .shelf { shelf.refreshFromDisk() }
+            // Rates update on a timer already; opening the tab asks once more
+            // so a stale cache from the last few hours does not sit there.
+            if tab == .currency { currencies.refreshIfNeeded() }
             // Leaving the notes sweeps out the blank ones — they cost one
             // hover to recreate, and a trail of empty cards is the clutter a
             // scratchpad exists to avoid.
@@ -210,6 +223,7 @@ final class NotchViewModel: ObservableObject {
     let screenshotFolder: ScreenshotFolderWatcher
     let calendar: CalendarStore
     let translator: Translator
+    let currencies: CurrencyStore
     let snippets: SnippetStore
     let notes: NoteStore
     let teleprompter: TeleprompterStore
@@ -225,6 +239,7 @@ final class NotchViewModel: ObservableObject {
         self.screenshotFolder = ScreenshotFolderWatcher()
         self.calendar = CalendarStore()
         self.translator = Translator()
+        self.currencies = CurrencyStore()
         self.snippets = SnippetStore()
         self.notes = NoteStore()
         self.teleprompter = TeleprompterStore()
@@ -242,12 +257,13 @@ final class NotchViewModel: ObservableObject {
         // `isOpen` is itself @Published and its own send does that.
         //
         // The stores with a text field in their pane — the translator, the
-        // snippets and the notes — are deliberately absent. They change on every
-        // keystroke, and redrawing the whole panel per letter costs more than a
-        // stale counter: it rebuilds the field, which drops the focus, so the
-        // first letter typed is also the last one that lands. Their panes
-        // observe them directly, and the header counter refreshes anyway,
-        // because the list is only ever re-read on the way into the tab.
+        // currency converter, the snippets and the notes — are deliberately
+        // absent. They change on every keystroke, and redrawing the whole
+        // panel per letter costs more than a stale counter: it rebuilds the
+        // field, which drops the focus, so the first letter typed is also the
+        // last one that lands. Their panes observe them directly, and the
+        // header counter refreshes anyway, because the list is only ever
+        // re-read on the way into the tab.
         for child in [
             media.objectWillChange,
             shelf.objectWillChange,

--- a/Sources/Cyclop/Services/CurrencyStore.swift
+++ b/Sources/Cyclop/Services/CurrencyStore.swift
@@ -1,0 +1,326 @@
+import AppKit
+import Foundation
+
+/// Live exchange rates from [fawazahmed0/exchange-api](https://github.com/fawazahmed0/exchange-api).
+///
+/// The CDN is the primary host; Cloudflare Pages is the documented fallback.
+/// Rates land once a day upstream, so this store refreshes every few hours and
+/// again whenever the source currency changes — that is the base the API
+/// returns rates against.
+@MainActor
+final class CurrencyStore: ObservableObject {
+    struct Currency: Identifiable, Hashable {
+        let code: String
+        let name: String
+        var id: String { code }
+        var displayCode: String { code.uppercased() }
+    }
+
+    /// Which amount field last drove the pair — typing on one side must not
+    /// bounce back through the other and fight the caret.
+    enum Side { case source, target }
+
+    @Published private(set) var currencies: [Currency] = []
+    /// Rates for `rateBase`, keyed by lowercase code: one unit of the base
+    /// buys this many of the key.
+    @Published private(set) var rates: [String: Double] = [:]
+    @Published private(set) var rateBase = ""
+    @Published private(set) var rateDate: String?
+    @Published private(set) var isLoading = false
+    @Published private(set) var failure: String?
+
+    @Published var sourceCode: String {
+        didSet {
+            guard sourceCode != oldValue else { return }
+            persistPair()
+            Task { await refreshRates(force: true) }
+            if !suppressSideEffects { recompute(from: .source) }
+        }
+    }
+
+    @Published var targetCode: String {
+        didSet {
+            guard targetCode != oldValue else { return }
+            persistPair()
+            if !suppressSideEffects { recompute(from: .source) }
+        }
+    }
+
+    @Published var sourceText = "1"
+    @Published var targetText = ""
+
+    private var timer: Timer?
+    private var editing: Side = .source
+    /// Quiet while both ends of a swap are rewritten, so the intermediate
+    /// equal-codes moment never fires a convert against the wrong rate table.
+    private var suppressSideEffects = false
+    private let refreshInterval: TimeInterval = 3 * 60 * 60
+    private let defaults = UserDefaults.standard
+    private let sourceKey = "currency.source"
+    private let targetKey = "currency.target"
+
+    private static let primaryHost = "https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1"
+    private static let fallbackHost = "https://latest.currency-api.pages.dev/v1"
+
+    init() {
+        let savedSource = defaults.string(forKey: sourceKey)?.lowercased()
+        let savedTarget = defaults.string(forKey: targetKey)?.lowercased()
+        sourceCode = savedSource ?? Self.defaultSource
+        targetCode = savedTarget ?? Self.defaultTarget
+        if sourceCode == targetCode {
+            targetCode = sourceCode == "usd" ? "eur" : "usd"
+        }
+    }
+
+    /// USD out, and the Mac's own currency in — or RUB when the locale has no
+    /// currency of its own worth converting against.
+    private static var defaultSource: String { "usd" }
+    private static var defaultTarget: String {
+        let code = Locale.current.currency?.identifier.lowercased()
+        if let code, code != "usd", !code.isEmpty { return code }
+        return "rub"
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        Task { await bootstrap() }
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: refreshInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in await self?.refreshRates(force: true) }
+        }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    /// Called when the tab is shown: a stale cache from hours ago is fine for
+    /// a glance, but opening the tab is a good moment to ask again without
+    /// waiting for the timer.
+    func refreshIfNeeded() {
+        Task { await refreshRates(force: false) }
+    }
+
+    // MARK: - Amounts
+
+    func setSourceText(_ text: String) {
+        editing = .source
+        sourceText = text
+        recompute(from: .source)
+    }
+
+    func setTargetText(_ text: String) {
+        editing = .target
+        targetText = text
+        recompute(from: .target)
+    }
+
+    func swap() {
+        let previousSource = sourceCode
+        let previousSourceText = sourceText
+        suppressSideEffects = true
+        sourceCode = targetCode
+        targetCode = previousSource
+        suppressSideEffects = false
+        // Keep the figure that was typed; the other side follows once rates
+        // for the new source land. If they are already cached, recompute now.
+        sourceText = previousSourceText
+        editing = .source
+        if rateBase == sourceCode {
+            recompute(from: .source)
+        }
+    }
+
+    func filtered(query: String) -> [Currency] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return currencies }
+        return currencies.filter {
+            $0.code.contains(q) || $0.name.lowercased().contains(q)
+        }
+    }
+
+    func name(for code: String) -> String {
+        currencies.first { $0.code == code }?.name ?? code.uppercased()
+    }
+
+    // MARK: - Networking
+
+    private func bootstrap() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            try await loadCurrencies()
+            try await loadRates(for: sourceCode)
+            failure = nil
+            recompute(from: editing)
+        } catch {
+            failure = error.localizedDescription
+        }
+    }
+
+    private func refreshRates(force: Bool) async {
+        if !force, rateBase == sourceCode, !rates.isEmpty { return }
+        do {
+            if currencies.isEmpty { try await loadCurrencies() }
+            try await loadRates(for: sourceCode)
+            failure = nil
+            recompute(from: editing)
+        } catch {
+            // Keep whatever rates we already have; only surface the error when
+            // there is nothing to convert with.
+            if rates.isEmpty { failure = error.localizedDescription }
+        }
+    }
+
+    private func loadCurrencies() async throws {
+        let data = try await fetch("currencies.min.json")
+        let decoded = try JSONDecoder().decode([String: String].self, from: data)
+        currencies = decoded
+            .map { Currency(code: $0.key.lowercased(), name: $0.value.isEmpty ? $0.key.uppercased() : $0.value) }
+            .sorted {
+                if $0.code == $1.code { return false }
+                // Everyday fiat first, then the long tail alphabetically.
+                let a = Self.pinboard.contains($0.code)
+                let b = Self.pinboard.contains($1.code)
+                if a != b { return a && !b }
+                if a, b {
+                    return Self.pinboard.firstIndex(of: $0.code)! < Self.pinboard.firstIndex(of: $1.code)!
+                }
+                return $0.code < $1.code
+            }
+        if !currencies.contains(where: { $0.code == sourceCode }) {
+            sourceCode = currencies.first?.code ?? "usd"
+        }
+        if !currencies.contains(where: { $0.code == targetCode }) {
+            targetCode = currencies.first { $0.code != sourceCode }?.code ?? "eur"
+        }
+    }
+
+    private func loadRates(for base: String) async throws {
+        let code = base.lowercased()
+        let data = try await fetch("currencies/\(code).min.json")
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let date = object?["date"] as? String
+        let table = object?[code] as? [String: Any] ?? [:]
+        var parsed: [String: Double] = [code: 1]
+        for (key, value) in table {
+            if let number = value as? Double {
+                parsed[key.lowercased()] = number
+            } else if let number = value as? NSNumber {
+                parsed[key.lowercased()] = number.doubleValue
+            }
+        }
+        rates = parsed
+        rateBase = code
+        rateDate = date
+    }
+
+    /// Tries the jsDelivr CDN first, then the Cloudflare Pages mirror the
+    /// upstream README asks every client to keep as a fallback.
+    private func fetch(_ endpoint: String) async throws -> Data {
+        var lastError: Error?
+        for host in [Self.primaryHost, Self.fallbackHost] {
+            guard let url = URL(string: "\(host)/\(endpoint)") else { continue }
+            do {
+                let (data, response) = try await URLSession.shared.data(from: url)
+                if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+                    throw URLError(.badServerResponse)
+                }
+                return data
+            } catch {
+                lastError = error
+            }
+        }
+        throw lastError ?? URLError(.cannotConnectToHost)
+    }
+
+    // MARK: - Conversion
+
+    private func recompute(from side: Side) {
+        // Rates belong to a specific base. Stale tables from the previous
+        // source must not invent a conversion.
+        guard rateBase == sourceCode.lowercased(),
+              let rate = rates[targetCode.lowercased()], rate > 0 else {
+            return
+        }
+        switch side {
+        case .source:
+            let trimmed = sourceText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                targetText = ""
+                return
+            }
+            guard let amount = Self.parse(sourceText) else { return }
+            targetText = Self.format(amount * rate)
+        case .target:
+            let trimmed = targetText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                sourceText = ""
+                return
+            }
+            guard let amount = Self.parse(targetText) else { return }
+            sourceText = Self.format(amount / rate)
+        }
+    }
+
+    private func persistPair() {
+        defaults.set(sourceCode, forKey: sourceKey)
+        defaults.set(targetCode, forKey: targetKey)
+    }
+
+    /// Currencies people actually reach for, pinned to the top of the picker.
+    private static let pinboard: [String] = [
+        "usd", "eur", "rub", "gbp", "cny", "jpy", "chf", "try", "kzt", "uah",
+        "byn", "pln", "aed", "btc", "eth", "usdt",
+    ]
+
+    /// Accepts both "1 234,56" and "1234.56". Empty and lone separators are
+    /// not numbers — the other field stays put so a mid-edit "1." does not
+    /// wipe the result.
+    static func parse(_ text: String) -> Double? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        var normalized = trimmed
+            .replacingOccurrences(of: "\u{00a0}", with: "")
+            .replacingOccurrences(of: " ", with: "")
+        if normalized.contains(","), normalized.contains(".") {
+            // "1,234.56" vs "1.234,56" — the rightmost separator is decimal.
+            if let lastComma = normalized.lastIndex(of: ","),
+               let lastDot = normalized.lastIndex(of: ".") {
+                if lastComma > lastDot {
+                    normalized = normalized.replacingOccurrences(of: ".", with: "")
+                    normalized = normalized.replacingOccurrences(of: ",", with: ".")
+                } else {
+                    normalized = normalized.replacingOccurrences(of: ",", with: "")
+                }
+            }
+        } else {
+            normalized = normalized.replacingOccurrences(of: ",", with: ".")
+        }
+        guard let value = Double(normalized), value.isFinite else { return nil }
+        return value
+    }
+
+    /// Compact enough for the panel: whole numbers stay whole, fiat keeps a
+    /// couple of decimals, tiny crypto rates keep more.
+    static func format(_ value: Double) -> String {
+        guard value.isFinite else { return "" }
+        let abs = abs(value)
+        let fraction: Int
+        if abs >= 1000 { fraction = 2 }
+        else if abs >= 1 { fraction = 2 }
+        else if abs >= 0.01 { fraction = 4 }
+        else if abs >= 0.0001 { fraction = 6 }
+        else { fraction = 8 }
+
+        let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: appLanguage)
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = fraction
+        formatter.usesGroupingSeparator = true
+        return formatter.string(from: NSNumber(value: value)) ?? String(value)
+    }
+}

--- a/Sources/Cyclop/Services/CurrencyStore.swift
+++ b/Sources/Cyclop/Services/CurrencyStore.swift
@@ -54,10 +54,20 @@ final class CurrencyStore: ObservableObject {
     /// Quiet while both ends of a swap are rewritten, so the intermediate
     /// equal-codes moment never fires a convert against the wrong rate table.
     private var suppressSideEffects = false
-    private let refreshInterval: TimeInterval = 3 * 60 * 60
+    private let refreshInterval: TimeInterval = 60 * 60
     private let defaults = UserDefaults.standard
     private let sourceKey = "currency.source"
     private let targetKey = "currency.target"
+    /// Own session rather than `URLSession.shared`: jsDelivr sends
+    /// `max-age=604800` on these files, and the shared cache would keep
+    /// serving yesterday's rates for a week no matter how often we "refresh".
+    private let session: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        config.urlCache = nil
+        config.timeoutIntervalForRequest = 20
+        return URLSession(configuration: config)
+    }()
 
     private static let primaryHost = "https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1"
     private static let fallbackHost = "https://latest.currency-api.pages.dev/v1"
@@ -86,9 +96,14 @@ final class CurrencyStore: ObservableObject {
     func start() {
         Task { await bootstrap() }
         timer?.invalidate()
-        timer = Timer.scheduledTimer(withTimeInterval: refreshInterval, repeats: true) { [weak self] _ in
+        let timer = Timer(timeInterval: refreshInterval, repeats: true) { [weak self] _ in
             Task { @MainActor in await self?.refreshRates(force: true) }
         }
+        // Common Mode, not just the default one: while a tracking loop or a
+        // scroll is running the default mode pauses, and a currency refresh
+        // queued for "in an hour" would quietly slip past.
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
     }
 
     func stop() {
@@ -96,11 +111,11 @@ final class CurrencyStore: ObservableObject {
         timer = nil
     }
 
-    /// Called when the tab is shown: a stale cache from hours ago is fine for
-    /// a glance, but opening the tab is a good moment to ask again without
-    /// waiting for the timer.
+    /// Opening the tab always asks the network again. Skipping when a table is
+    /// already in memory is what made yesterday's rates look permanent: the
+    /// timer alone is not enough if the app was quit overnight.
     func refreshIfNeeded() {
-        Task { await refreshRates(force: false) }
+        Task { await refreshRates(force: true) }
     }
 
     // MARK: - Amounts
@@ -161,7 +176,7 @@ final class CurrencyStore: ObservableObject {
     }
 
     private func refreshRates(force: Bool) async {
-        if !force, rateBase == sourceCode, !rates.isEmpty { return }
+        if !force, rateBase == sourceCode, !rates.isEmpty, !isStaleDate { return }
         do {
             if currencies.isEmpty { try await loadCurrencies() }
             try await loadRates(for: sourceCode)
@@ -172,6 +187,21 @@ final class CurrencyStore: ObservableObject {
             // there is nothing to convert with.
             if rates.isEmpty { failure = error.localizedDescription }
         }
+    }
+
+    /// Upstream publishes once a day. A table whose `date` is not today is the
+    /// one case where skipping a refresh is definitely wrong.
+    private var isStaleDate: Bool {
+        guard let rateDate else { return true }
+        return rateDate != Self.todayStamp()
+    }
+
+    private static func todayStamp() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date())
     }
 
     private func loadCurrencies() async throws {
@@ -223,8 +253,12 @@ final class CurrencyStore: ObservableObject {
         var lastError: Error?
         for host in [Self.primaryHost, Self.fallbackHost] {
             guard let url = URL(string: "\(host)/\(endpoint)") else { continue }
+            var request = URLRequest(url: url)
+            request.cachePolicy = .reloadIgnoringLocalCacheData
+            request.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
+            request.setValue("no-cache", forHTTPHeaderField: "Pragma")
             do {
-                let (data, response) = try await URLSession.shared.data(from: url)
+                let (data, response) = try await session.data(for: request)
                 if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
                     throw URLError(.badServerResponse)
                 }

--- a/Sources/Cyclop/UI/CurrencyPane.swift
+++ b/Sources/Cyclop/UI/CurrencyPane.swift
@@ -1,0 +1,263 @@
+import SwiftUI
+
+/// Two editable amounts, source on the left and result on the right — the same
+/// shape as the translator, because both are "type on one side, read the
+/// other". Either side accepts a figure; the empty one follows.
+struct CurrencyPane: View {
+    @ObservedObject var currencies: CurrencyStore
+    @Binding var wantsKeyboard: Bool
+
+    private enum Field { case source, target, search }
+    private enum PickerSide { case source, target }
+
+    @FocusState private var focused: Field?
+    @State private var picking: PickerSide?
+    @State private var query = ""
+
+    var body: some View {
+        Group {
+            if let picking {
+                picker(for: picking)
+            } else {
+                converter
+            }
+        }
+        .padding(.top, 2)
+        .onAppear {
+            currencies.refreshIfNeeded()
+            if wantsKeyboard { focused = .source }
+        }
+        .onChange(of: wantsKeyboard) { _, wants in
+            if wants {
+                focused = picking == nil ? .source : .search
+            } else {
+                focused = nil
+            }
+        }
+    }
+
+    // MARK: - Converter
+
+    private var converter: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top, spacing: 8) {
+                amountColumn(
+                    code: currencies.sourceCode,
+                    name: currencies.name(for: currencies.sourceCode),
+                    side: .source,
+                    text: Binding(
+                        get: { currencies.sourceText },
+                        set: { currencies.setSourceText($0) }
+                    )
+                )
+
+                Button {
+                    currencies.swap()
+                } label: {
+                    Image(systemName: "arrow.left.arrow.right")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Theme.secondary)
+                        .frame(width: 28, height: 28)
+                        .background(
+                            Circle().fill(Theme.surface)
+                        )
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 28)
+                .help(localized("Swap currencies"))
+
+                amountColumn(
+                    code: currencies.targetCode,
+                    name: currencies.name(for: currencies.targetCode),
+                    side: .target,
+                    text: Binding(
+                        get: { currencies.targetText },
+                        set: { currencies.setTargetText($0) }
+                    )
+                )
+            }
+
+            if let failure = currencies.failure, currencies.rates.isEmpty {
+                Text(failure)
+                    .font(.system(size: 10))
+                    .foregroundStyle(Theme.secondary)
+                    .lineLimit(2)
+            }
+        }
+    }
+
+    private func amountColumn(
+        code: String,
+        name: String,
+        side: Field,
+        text: Binding<String>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Button {
+                query = ""
+                picking = side == .source ? .source : .target
+                if wantsKeyboard { focused = .search }
+            } label: {
+                HStack(spacing: 6) {
+                    Text(code.uppercased())
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.white)
+                    Text(name)
+                        .font(.system(size: 10))
+                        .foregroundStyle(Theme.tertiary)
+                        .lineLimit(1)
+                    Spacer(minLength: 2)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(Theme.tertiary)
+                }
+                .padding(.horizontal, 8)
+                .frame(height: 22)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Theme.surface)
+                )
+            }
+            .buttonStyle(.plain)
+
+            TextField("0", text: text)
+            .textFieldStyle(.plain)
+            .font(.system(size: 26, weight: .medium).monospacedDigit())
+            .foregroundStyle(.white)
+            .tint(Theme.secondary)
+            .focused($focused, equals: side)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(Theme.surface)
+            )
+            .onKeyPress(.escape) {
+                text.wrappedValue = ""
+                return .handled
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    // MARK: - Picker
+
+    private func picker(for side: PickerSide) -> some View {
+        let selected = side == .source ? currencies.sourceCode : currencies.targetCode
+        let matches = currencies.filtered(query: query)
+
+        return VStack(spacing: 6) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(Theme.tertiary)
+                TextField(localized("Search currency"), text: $query)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white)
+                    .tint(Theme.secondary)
+                    .focused($focused, equals: .search)
+                    .onKeyPress(.escape) {
+                        if query.isEmpty {
+                            closePicker()
+                        } else {
+                            query = ""
+                        }
+                        return .handled
+                    }
+                if !query.isEmpty {
+                    Button { query = "" } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(Theme.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+                Button(localized("Done")) { closePicker() }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.white)
+            }
+            .padding(.horizontal, 9)
+            .frame(height: 24)
+            .background(
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .fill(Theme.surface)
+            )
+
+            if let failure = currencies.failure, currencies.currencies.isEmpty {
+                Text(failure)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .padding(.top, 8)
+            } else if matches.isEmpty {
+                Text(localized("No currencies match"))
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .padding(.top, 8)
+            } else {
+                ScrollView(showsIndicators: false) {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(matches) { currency in
+                            Button {
+                                choose(currency.code, for: side)
+                            } label: {
+                                HStack(spacing: 8) {
+                                    Text(currency.displayCode)
+                                        .font(.system(size: 11, weight: .semibold).monospaced())
+                                        .foregroundStyle(.white)
+                                        .frame(width: 44, alignment: .leading)
+                                    Text(currency.name)
+                                        .font(.system(size: 11))
+                                        .foregroundStyle(Theme.secondary)
+                                        .lineLimit(1)
+                                    Spacer(minLength: 0)
+                                    if currency.code == selected {
+                                        Image(systemName: "checkmark")
+                                            .font(.system(size: 10, weight: .bold))
+                                            .foregroundStyle(.white)
+                                    }
+                                }
+                                .padding(.horizontal, 8)
+                                .frame(height: 26)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                        .fill(currency.code == selected ? Theme.surfaceHover : Color.clear)
+                                )
+                                .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear { if wantsKeyboard { focused = .search } }
+    }
+
+    private func choose(_ code: String, for side: PickerSide) {
+        switch side {
+        case .source:
+            if code == currencies.targetCode {
+                currencies.swap()
+            } else {
+                currencies.sourceCode = code
+            }
+        case .target:
+            if code == currencies.sourceCode {
+                currencies.swap()
+            } else {
+                currencies.targetCode = code
+            }
+        }
+        closePicker()
+    }
+
+    private func closePicker() {
+        picking = nil
+        query = ""
+        if wantsKeyboard { focused = .source }
+    }
+}

--- a/Sources/Cyclop/UI/CurrencyPane.swift
+++ b/Sources/Cyclop/UI/CurrencyPane.swift
@@ -63,6 +63,7 @@ struct CurrencyPane: View {
                         )
                 }
                 .buttonStyle(.plain)
+                .pointerStyle(.default)
                 .padding(.top, 28)
                 .help(localized("Swap currencies"))
 
@@ -119,6 +120,7 @@ struct CurrencyPane: View {
                 )
             }
             .buttonStyle(.plain)
+            .pointerStyle(.default)
 
             TextField("0", text: text)
             .textFieldStyle(.plain)
@@ -172,9 +174,11 @@ struct CurrencyPane: View {
                             .foregroundStyle(Theme.secondary)
                     }
                     .buttonStyle(.plain)
+                    .pointerStyle(.default)
                 }
                 Button(localized("Done")) { closePicker() }
                     .buttonStyle(.plain)
+                    .pointerStyle(.default)
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.white)
             }

--- a/Sources/Cyclop/UI/NotchContentView.swift
+++ b/Sources/Cyclop/UI/NotchContentView.swift
@@ -97,6 +97,8 @@ struct NotchContentView: View {
             // Nothing: the columns name both languages already, and the strip
             // is the one part of the panel worth not spending on a repeat.
             EmptyView()
+        case .currency:
+            CurrencyRateDate(currencies: vm.currencies)
         case .notes:
             NotesCounter(notes: vm.notes)
         case .teleprompter:
@@ -164,6 +166,8 @@ struct NotchContentView: View {
             SnippetsPane(snippets: vm.snippets, privacy: vm.privacy, wantsKeyboard: $panel.wantsKeyboard)
         case .translate:
             TranslatePane(translator: vm.translator, wantsKeyboard: $panel.wantsKeyboard)
+        case .currency:
+            CurrencyPane(currencies: vm.currencies, wantsKeyboard: $panel.wantsKeyboard)
         case .notes:
             NotesPane(notes: vm.notes, privacy: vm.privacy, wantsKeyboard: $panel.wantsKeyboard)
         case .teleprompter:
@@ -184,6 +188,21 @@ private struct NotesCounter: View {
     var body: some View {
         if !notes.notes.isEmpty {
             Text("\(notes.notes.count)")
+                .font(.system(size: 10, weight: .medium).monospacedDigit())
+                .foregroundStyle(Theme.tertiary)
+        }
+    }
+}
+
+/// Same reason as `NotesCounter`: rate fetches must not redraw the whole panel
+/// on every keystroke in the amount fields, so the date badge observes the
+/// store on its own.
+private struct CurrencyRateDate: View {
+    @ObservedObject var currencies: CurrencyStore
+
+    var body: some View {
+        if let date = currencies.rateDate {
+            Text(date)
                 .font(.system(size: 10, weight: .medium).monospacedDigit())
                 .foregroundStyle(Theme.tertiary)
         }


### PR DESCRIPTION
## Summary
- Новая вкладка «Валюта» сразу после переводчика (правая рейка)
- Курсы и список валют из [fawazahmed0/exchange-api](https://github.com/fawazahmed0/exchange-api) с fallback на Cloudflare Pages
- Периодическое обновление курсов, поиск валюты по коду и названию, ввод суммы с обеих сторон

## Test plan
- [ ] Собрать `./Scripts/bundle.sh` и открыть панель
- [ ] Открыть вкладку «Валюта», дождаться загрузки курсов (дата в шапке)
- [ ] Конвертация USD → локальная валюта / RUB при вводе слева и справа
- [ ] Поиск валюты по коду (`btc`) и по названию (`Euro`)
- [ ] Смена валют и кнопка обмена; пара сохраняется после перезапуска
- [ ] При недоступном jsDelivr курсы подтягиваются с fallback