### PR TITLE
Пустой сценарий суфлёра открывается редактором, в который можно писать

### DIFF
--- a/Sources/Cyclop/UI/TeleprompterPane.swift
+++ b/Sources/Cyclop/UI/TeleprompterPane.swift
@@ -24,15 +24,38 @@ struct TeleprompterPane: View {
         .padding(.top, 2)
         .onChange(of: wantsKeyboard) { _, wants in
             focused = wants && editing
-            // The keyboard going elsewhere means attention went with it.
-            if !wants { editing = false }
+            // The keyboard going elsewhere means attention went with it — but
+            // not on an empty script, where the editor is the only thing this
+            // tab can show. Saying it is not being edited would be untrue, and
+            // the first character typed would then hand the pane to the reader
+            // in mid-word.
+            if !wants, !prompter.script.isEmpty { editing = false }
         }
         // Arriving puts the script back at the top. A take starts at the
         // beginning, and mid-take nobody is switching tabs — so the only way
         // to arrive on a script left halfway is to have finished with it, and
         // the one thing that must not happen then is opening onto the blank
         // space past the last line with no way to tell why it is blank.
-        .onAppear { prompter.rewind() }
+        .onAppear {
+            prompter.rewind()
+            // An empty script has nothing to read, so the tab opens into the
+            // editor — and an editor the keyboard never reaches is a field
+            // that cannot be typed or pasted into at all (#53). The one button
+            // that would hand it over is the ✎, and it is on the other branch
+            // of these controls; the panel does not offer it on arrival either,
+            // because reading a script is not typing (`Tab.needsKeyboard`).
+            //
+            // So this state asks the way the ✎ asks. Hovering onto an empty
+            // teleprompter does take the keyboard from the window underneath,
+            // and that is the trade `PanelState.select` already names: showing
+            // a field one cannot type into is worse than briefly dimming the
+            // caret below. It happens once — a script that exists is read, not
+            // written, and this branch is never taken again.
+            guard prompter.script.isEmpty else { return }
+            editing = true
+            wantsKeyboard = true
+            focused = true
+        }
         .onDisappear { prompter.suspend() }
     }
 


### PR DESCRIPTION
Closes #53.

Открываешь суфлёр в первый раз — редактор на экране, плейсхолдер «Paste the script here» на месте, а набрать или вставить в него нельзя вообще ничем. То есть вкладкой невозможно начать пользоваться.

Причин на самом деле две, и вторая важнее той, что в issue.

**Первая — фокус.** Редактор показывается при `editing || script.isEmpty`, а фокус выставляется при `wants && editing`. На пустом сценарии первое верно, второе нет.

**Вторая — клавиатура.** `Tab.needsKeyboard` не включает суфлёр, и правильно не включает: сценарий читают, глядя в камеру, а не набирают. Но из-за этого панель не берёт клавиатуру ни на входе во вкладку, ни по клику внутрь — `panel.onPress` смотрит на тот же список. Так что даже с починенным фокусом поле осталось бы мёртвым: `acceptsKeyboard` у окна `false`.

Поэтому патч из issue я взял не целиком. Он ставит `focused = true`, но не просит клавиатуру, и у меня без второй половины не заработало.

**Что сделано.** Пустой сценарий на входе просит клавиатуру ровно так же, как это делает кнопка ✎ — `editing = true`, `wantsKeyboard = true`. Плюс `editing` больше не сбрасывается в `false`, пока сценарий пуст: показывать при этом нечего, кроме редактора, и первый же набранный символ иначе перекидывал панель на читалку посреди слова.

**Про размен.** Наведение на пустой суфлёр теперь забирает клавиатуру у окна снизу. Это ровно тот размен, который уже назван в `PanelState.select`: «показывать поле, в которое нельзя писать, хуже, чем ненадолго погасить каретку под панелью». И случается он один раз — сценарий, который уже есть, читают, а не пишут, и в эту ветку больше не заходят.

Что не чинится этим PR: если посреди сессии клавиатура ушла в другое приложение, а сценарий всё ещё пуст, клик обратно в редактор её не вернёт — `onPress` по-прежнему сверяется с `needsKeyboard`. Панель при этом всё равно свернётся, как только уедет курсор, и следующее наведение снова заходит через `onAppear`. Чинить это по-настоящему — трогать `onPress`, а это уже про другое.

Собрал начисто на Swift 6.3.3 / macOS 26, без ошибок и предупреждений. Новых строк на экране нет, так что таблицы переводов не трогал.

---

@frizzyTAIM thanks for the report — the diagnosis in it was right, and the repro was exact. I ended up not taking the patch as-is: `focused = true` alone wasn't enough here, because the panel window itself doesn't accept key events on this tab (`Tab.needsKeyboard` deliberately excludes the teleprompter), so the pane has to ask for the keyboard the way the ✎ button does. Everything else follows your reading of it.
