### PR TITLE
Обещание про потоки записано в коде, а не в языковом режиме пятилетней давности

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .executableTarget(
             name: "Cyclop",
             path: "Sources/Cyclop",
-            swiftSettings: [.swiftLanguageMode(.v5)]
+            swiftSettings: [.swiftLanguageMode(.v6)]
         )
     ]
 )

--- a/Sources/Cyclop/Notch/NotchController.swift
+++ b/Sources/Cyclop/Notch/NotchController.swift
@@ -40,7 +40,7 @@ final class NotchController {
 
     /// Sleeping, waking and changing desktop are facts about the session, not
     /// about one display, so every screen hears them.
-    private func onWorkspace(_ name: Notification.Name, _ body: @escaping (NotchScreenPanel) -> Void) {
+    private func onWorkspace(_ name: Notification.Name, _ body: @escaping @MainActor (NotchScreenPanel) -> Void) {
         NSWorkspace.shared.notificationCenter.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
             MainActor.assumeIsolated { self?.panels.values.forEach(body) }
         }

--- a/Sources/Cyclop/Services/PlayerBridge.swift
+++ b/Sources/Cyclop/Services/PlayerBridge.swift
@@ -46,6 +46,11 @@ struct PlayerState {
     var key: String { "\(app.rawValue)|\(title)|\(artist)|\(album)" }
 }
 
+/// Called from the panel and answering to it: every entry point here is
+/// reached from `MediaController`, and every completion is delivered back on
+/// the main thread. Saying so out loud is what `.v6` asks for — the work still
+/// happens on `queue` and in `URLSession`, and only the answer comes home.
+@MainActor
 enum PlayerBridge {
     private static let queue = DispatchQueue(label: "com.cyclop.applescript", qos: .utility)
 
@@ -129,7 +134,7 @@ enum PlayerBridge {
 
     // MARK: - Artwork
 
-    static func artwork(for state: PlayerState, completion: @escaping (NSImage?) -> Void) {
+    static func artwork(for state: PlayerState, completion: @escaping @MainActor (NSImage?) -> Void) {
         switch state.app {
         case .spotify:
             // The one thing the app ever fetches over the network. The address
@@ -141,7 +146,7 @@ enum PlayerBridge {
             }
             URLSession.shared.dataTask(with: url) { data, _, _ in
                 let image = data.flatMap(NSImage.init(data:))
-                DispatchQueue.main.async { completion(image) }
+                DispatchQueue.main.async { MainActor.assumeIsolated { completion(image) } }
             }.resume()
         case .music:
             runScript("""
@@ -216,14 +221,14 @@ enum PlayerBridge {
     }
 
     /// Shared AppleScript runner: one serial queue for every script the app sends.
-    static func runScript(_ source: String, completion: @escaping (NSAppleEventDescriptor?) -> Void) {
+    static func runScript(_ source: String, completion: @escaping @MainActor (NSAppleEventDescriptor?) -> Void) {
         queue.async {
             var error: NSDictionary?
             let result = NSAppleScript(source: source)?.executeAndReturnError(&error)
             if let error, let code = error[NSAppleScript.errorNumber] as? Int, code != 0 {
                 NSLog("Cyclop: AppleScript error \(code): \(error[NSAppleScript.errorMessage] ?? "")")
             }
-            DispatchQueue.main.async { completion(result) }
+            DispatchQueue.main.async { MainActor.assumeIsolated { completion(result) } }
         }
     }
 }

--- a/Sources/Cyclop/Services/Translator.swift
+++ b/Sources/Cyclop/Services/Translator.swift
@@ -67,7 +67,7 @@ final class Translator: ObservableObject {
         clear()
     }
 
-    func run(_ session: TranslationSession) async {
+    func run(_ session: sending TranslationSession) async {
         let text = trimmed
         guard !text.isEmpty else { clear(); return }
         guard let source = session.sourceLanguage, let target = session.targetLanguage else { return }


### PR DESCRIPTION
Closes #56.

`swift-tools-version: 6.0`, а таргет собирается с `.swiftLanguageMode(.v5)` — то есть тулчейн шестой, а проверки concurrency пятые. Ты сказал «давай PR», вот он.

**Поправок вышло четыре, а не три.** В issue я насчитал три места, но с тех пор в main приехали панели на все экраны, и вместе с ними — четвёртое, в `NotchController.onWorkspace`. Дальше их не станет больше только если режим включить; сейчас каждый новый хоп на фон и обратно добавляет по одному молча.

**Что именно.**

`PlayerBridge` стал `@MainActor` целиком. Это не новое ограничение, а запись того, что и так было: все входы сюда — из `MediaController`, который `@MainActor`, и все ответы уже возвращались через `DispatchQueue.main.async`. Работа как шла на `queue` и в `URLSession`, так и идёт — домой приезжает только ответ.

Два коллбэка — обложка и `runScript` — помечены `@MainActor`, и возврат на главный обёрнут в `MainActor.assumeIsolated`. Так же, как это уже сделано в `NotchController`.

`Translator.run` берёт сессию как `sending`. `TranslationSession` не `Sendable`, и `await session.translate(text)` её отдаёт; `sending` говорит ровно то, что и происходит на деле — вызывающий её больше не трогает.

`onWorkspace` принимает `@escaping @MainActor` — тело и так вызывается внутри `assumeIsolated`.

**Проверил.** Начисто на Swift 6.3.3 / macOS 26: сборка чистая, **ноль ошибок и ноль предупреждений**. Плюс оба шага из CI руками — `./Scripts/bundle.sh release` и `./Scripts/test-helper.sh` (хелпер ответил снимком).

Поведение не меняется: ни одного нового хопа, ни одного нового `await`, ни одной строки на экране. Диф — 12 строк добавлено, 7 убрано.

Про тесты завёл отдельно, как договаривались.
