### PR TITLE
Правка заготовки не стирает соседнюю

### DIFF
--- a/Sources/Cyclop/Services/SnippetStore.swift
+++ b/Sources/Cyclop/Services/SnippetStore.swift
@@ -180,11 +180,15 @@ final class SnippetStore: ObservableObject {
             NSLog("Cyclop: refusing to write over an unreadable snippets.json")
             return
         }
-        guard let index = items.firstIndex(where: { $0.id == snippet.id }) else { return }
         // An edit that turns this row into an exact copy of another one leaves
         // a single row, for the same reason `add` does.
         items.removeAll { $0.id == edited.id && $0.id != snippet.id }
-        items[min(index, items.count - 1)] = edited
+        // Found after the removal, never before it: a copy standing above this
+        // row shifts it up by one, and an index taken beforehand then points at
+        // the neighbour. Written there, the edit destroys a snippet nobody
+        // touched and leaves the edited one exactly as it was.
+        guard let index = items.firstIndex(where: { $0.id == snippet.id }) else { return }
+        items[index] = edited
         persist()
     }
 


### PR DESCRIPTION
Нашёл, читая #49 — правка на месте там сделана правильно, а вот в одном месте порядок двух строк даёт потерю данных.

В `SnippetStore.update` индекс ряда берётся **до** того, как удаляется дубликат:

```swift
guard let index = items.firstIndex(where: { $0.id == snippet.id }) else { return }
items.removeAll { $0.id == edited.id && $0.id != snippet.id }
items[min(index, items.count - 1)] = edited
```

Если копия лежит выше редактируемого ряда, после `removeAll` он сдвигается на единицу вверх, а `index` продолжает показывать на соседа. Туда и пишется правка. `min(...)` иногда компенсирует сдвиг, но только когда редактируемый ряд оказался последним — то есть маскирует ошибку, а не чинит её.

**Что происходит на деле.** Три заготовки, правим среднюю так, чтобы она стала точной копией первой:

```
до:        ["home=Кутузовский 1", "work=Тверская 7", "vpn=10.0.0.1"]
после:     ["work=Тверская 7", "home=Кутузовский 1"]
ожидалось: ["home=Кутузовский 1", "vpn=10.0.0.1"]
```

`vpn` исчез, хотя его никто не трогал, а `work` — тот самый ряд, который правили, — остался как был. То есть правка не применилась, зато пропала посторонняя запись, и `persist()` сразу записал это в `snippets.json`.

**Фикс — переставить две строки:** искать индекс после удаления, а не до. Тогда `min` становится не нужен, потому что ряд гарантированно на месте: `removeAll` его не трогает, там стоит `$0.id != snippet.id`.

Проверил обеими сторонами: на этом же наборе до правки — потеря, после — ожидаемый результат. Сборка чистая на Swift 6.3.3 / macOS 26.

Отдельно: это ровно тот случай, о котором ты писал в #56 — «чистые сторы тестируемы без UI». Здесь весь баг это три строки без единого вью, и один тест на них ловил бы его насмерть.
