### PR TITLE
Запасной маршрут к плееру перестал молчать

### DIFF
--- a/Sources/Cyclop/Services/PlayerBridge.swift
+++ b/Sources/Cyclop/Services/PlayerBridge.swift
@@ -166,14 +166,14 @@ enum PlayerBridge {
             \(sep)
             tell application id "com.spotify.client"
                 try
-                    set st to player state as text
+                    set pstate to player state as text
                     set t to current track
                     try
                         set pos to (round ((player position) * 1000))
                     on error
                         set pos to 0
                     end try
-                    return st & sep & (name of t) & sep & (artist of t) & sep & (album of t) & sep & (duration of t) & sep & pos & sep & (artwork url of t)
+                    return pstate & sep & (name of t) & sep & (artist of t) & sep & (album of t) & sep & (duration of t) & sep & pos & sep & (artwork url of t)
                 on error
                     return ""
                 end try
@@ -184,14 +184,14 @@ enum PlayerBridge {
             \(sep)
             tell application id "com.apple.Music"
                 try
-                    set st to player state as text
+                    set pstate to player state as text
                     set t to current track
                     try
                         set pos to (round ((player position) * 1000))
                     on error
                         set pos to 0
                     end try
-                    return st & sep & (name of t) & sep & (artist of t) & sep & (album of t) & sep & (round ((duration of t) * 1000)) & sep & pos & sep & ""
+                    return pstate & sep & (name of t) & sep & (artist of t) & sep & (album of t) & sep & (round ((duration of t) * 1000)) & sep & pos & sep & ""
                 on error
                     return ""
                 end try


### PR DESCRIPTION
## Что было сломано

Запасной путь чтения плеера — тот, на который приложение уходит, когда закрывается маршрут через MediaRemote, — не работал никогда. Ни разу с момента написания.

Причина в одном слове: **`st` — служебный токен AppleScript**, и переменной так называться нельзя.

```applescript
set st to player state as text
```

Скрипт разваливался при разборе, не долетев до плеера:

```
Cyclop: AppleScript error -2741: Expected expression but found "st".
```

Ломались **обе ветки сразу** — и `com.spotify.client`, и `com.apple.Music`.

## Почему выглядело странно

Ломалось только **чтение** — «что сейчас играет». Пауза, перемотка и обложка собираются другими скриптами, где `st` не встречается. Отсюда симптом, по которому трудно догадаться о причине: плеер играет, кнопки живые, а панель пустая.

## Почему этого никто не видел

Ветка включается, только когда закрывается путь через MediaRemote. На рабочей машине он не закрывается никогда — значит этот код **не выполнялся ни разу**.

Ни `swift build`, ни подпись, ни CI такого не ловят: они проверяют, что собралось и что файлы на месте, а не что скрипт отвечает. Ровно тот класс отказов, про который написано в `docs/release-checklist.md`.

## Как проверялось

Скрипт вынесен из приложения и прогнан через `osascript` — ошибка воспроизвелась один в один. Дальше сужение до трёх строк:

| строка | результат |
|---|---|
| `set zz to 1` | ok |
| `set st to 1` | `-2741 Expected expression but found "st"` |

То есть дело не в Spotify, не в разрешениях и не в `tell`-блоке. После переименования полный скрипт вернул нормальные данные:

```
playing␁NO LOVE␁LIL KRYSTALLL␁EASTERN PROMISE␁138461␁18591␁https://i.scdn.co/…
```

Формат ровно тот, который ждёт `parse()`.

## Проверено вживую

Приложение запущено с принудительно закрытым маршрутом MediaRemote:

- вкладка «Музыка» показывает трек, исполнителя, альбом и обложку
- пауза, перемотка и переключение треков работают
- `AppleScript error` в логе — **0** строк (до правки сыпалось каждые несколько секунд)

## Почему это важно

Маршрут запасной не на бумаге. С macOS 15.4 `mediaremoted` отвечает только доверенным клиентам. Когда эта дверь закроется совсем, приложение должно деградировать до Music и Spotify — а не онеметь целиком, как было бы сейчас.

## Проверки из CONTRIBUTING

```
./Scripts/bundle.sh release   ✓
./Scripts/test-helper.sh      ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiwN27TNEpisqnjcTQDqca