### PR TITLE
Курсор в телесуфлёре стоит там, где начинается подсказка

### DIFF
--- a/Sources/Cyclop/UI/TeleprompterPane.swift
+++ b/Sources/Cyclop/UI/TeleprompterPane.swift
@@ -110,11 +110,16 @@ struct TeleprompterPane: View {
             .padding(.horizontal, 14)
             .overlay(alignment: .topLeading) {
                 if prompter.script.isEmpty {
+                    // Offsets match where the editor actually puts its first
+                    // line, not where the rounded rectangle starts: 14 is the
+                    // padding above, 5 is the text container's own line
+                    // fragment padding. Getting this wrong parks the caret
+                    // above and left of the placeholder it is supposed to
+                    // stand in front of.
                     Text("Paste the script here")
                         .font(.system(size: 13, design: .rounded))
                         .foregroundStyle(Theme.tertiary)
-                        .padding(.horizontal, 20)
-                        .padding(.top, 8)
+                        .padding(.leading, 14 + 5)
                         .allowsHitTesting(false)
                 }
             }


### PR DESCRIPTION
## Что было

Подсказка «Paste the script here» отсчитывалась от угла скруглённого прямоугольника:

```swift
.padding(.horizontal, 20)
.padding(.top, 8)
```

А редактор ставит первую строку от **собственного** отступа: сверху нуля, слева пяти поверх внешних четырнадцати.

Расхождение и было видно глазом — каретка висела выше и левее той надписи, перед которой должна стоять.

## Что стало

```swift
.padding(.leading, 14 + 5)
```

Отступы теперь названы тем, чем являются: `14` — padding самого поля, `5` — line fragment padding текстового контейнера. Вертикального отступа нет, потому что его нет и у редактора.

Слагаемые оставлены не свёрнутыми в `19` намеренно: если поменяется внешний отступ поля, сразу видно, какое из двух чисел надо править.

## Проверено

- пустое поле: каретка стоит ровно в начале подсказки
- первый набранный символ появляется там же, где стояла каретка
- после очистки подсказка возвращается на место

## Проверки из CONTRIBUTING

```
./Scripts/bundle.sh release   ✓
./Scripts/test-helper.sh      ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiwN27TNEpisqnjcTQDqca