### PR TITLE
Вкладка Memory: давление RAM и очистка кэшей

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -18,6 +18,7 @@
 /* Settings tab */
 "General" = "General";
 "Launch at Login" = "Launch at Login";
+"Keep Awake with Lid Closed" = "Keep Awake with Lid Closed";
 "Screenshots" = "Screenshots";
 "Save Clipboard Screenshots" = "Save Clipboard Screenshots";
 "Show Screenshots Folder" = "Show Screenshots Folder";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -99,3 +99,24 @@
 "Paste the script here" = "Paste the script here";
 "Ready" = "Ready";
 "Done" = "Done";
+
+/* Usage tab: Claude's own limits, fetched live with the Claude Code CLI's own
+   OAuth token. */
+"Usage" = "Usage";
+"5-hour window" = "5-hour window";
+"7-day window" = "7-day window";
+"Extra usage" = "Extra usage";
+"Not signed in to Claude" = "Not signed in to Claude";
+"Sign in with claude in Terminal,\nthen reopen this tab" = "Sign in with claude in Terminal,\nthen reopen this tab";
+"Can't reach Claude" = "Can't reach Claude";
+"No Codex sessions found yet" = "No Codex sessions found yet";
+"%d-day window" = "%d-day window";
+"%d-hour window" = "%d-hour window";
+"resets in %@" = "resets in %@";
+"resets any moment" = "resets any moment";
+"as of %@ ago" = "as of %@ ago";
+"as of just now" = "as of just now";
+"Cursor Models" = "Cursor Models";
+"Other Models" = "Other Models";
+"Not signed in to Cursor" = "Not signed in to Cursor";
+"Can't reach Cursor" = "Can't reach Cursor";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -99,3 +99,17 @@
 "Paste the script here" = "Paste the script here";
 "Ready" = "Ready";
 "Done" = "Done";
+
+/* Pomodoro */
+"Pomodoro" = "Pomodoro";
+"Focus" = "Focus";
+"Break" = "Break";
+"Long Break" = "Long Break";
+"Classic" = "Classic";
+"Short" = "Short";
+"Long" = "Long";
+"Custom" = "Custom";
+"Reset" = "Reset";
+"Skip" = "Skip";
+"Focus done — time for a break" = "Focus done — time for a break";
+"Break over — back to focus" = "Break over — back to focus";

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -13,6 +13,9 @@
 
 /* Menu bar */
 "Open Panel" = "Open Panel";
+"Settings…" = "Settings…";
+"All Settings…" = "All Settings…";
+"Notch glows only when the graph is red." = "Notch glows only when the graph is red.";
 "Quit" = "Quit";
 
 /* Settings tab */
@@ -25,6 +28,7 @@
 "Clear Screenshots Folder" = "Clear Screenshots Folder";
 "Clear Screenshots Folder (%@)" = "Clear Screenshots Folder (%@)";
 "Show Snippets File" = "Show Snippets File";
+"No usage cards enabled — turn some on in Settings" = "No usage cards enabled — turn some on in Settings";
 
 /* Shelf */
 "Selected: %d" = "Selected: %d";
@@ -135,3 +139,54 @@
 "Skip" = "Skip";
 "Focus done — time for a break" = "Focus done — time for a break";
 "Break over — back to focus" = "Break over — back to focus";
+
+/* Memory tab: Activity Monitor's pressure graph, plus cache cleanup. */
+"Memory" = "Memory";
+"Memory Pressure · Green" = "Memory Pressure · Green";
+"Memory Pressure · Yellow" = "Memory Pressure · Yellow";
+"Memory Pressure · Red" = "Memory Pressure · Red";
+"Running optimally." = "Running optimally.";
+"Close unneeded tabs and quit unused apps." = "Close unneeded tabs and quit unused apps.";
+"The Mac is swapping. Close tabs, then clean caches below." = "The Mac is swapping. Close tabs, then clean caches below.";
+"Swap" = "Swap";
+"Disk free" = "Disk free";
+"Starts in 10 min" = "Starts in 10 min";
+"App & System Caches" = "App & System Caches";
+"Everything in ~/Library/Caches — every app rebuilds this from scratch." = "Everything in ~/Library/Caches — every app rebuilds this from scratch.";
+"npm Package Cache" = "npm Package Cache";
+"~/.npm — npm re-downloads packages as needed." = "~/.npm — npm re-downloads packages as needed.";
+"CLI Tool Cache" = "CLI Tool Cache";
+"~/.cache — shared cache folder used by many command-line dev tools." = "~/.cache — shared cache folder used by many command-line dev tools.";
+"pnpm Store" = "pnpm Store";
+"Runs “pnpm store prune” to drop packages nothing references anymore." = "Runs “pnpm store prune” to drop packages nothing references anymore.";
+"Docker Unused Data" = "Docker Unused Data";
+"Removes ALL unused images, containers, and volumes not currently in use — off by default, more destructive than the rest." = "Removes ALL unused images, containers, and volumes not currently in use — off by default, more destructive than the rest.";
+"App Cache Subfolders" = "App Cache Subfolders";
+"Cache-style folders (Cache, GPUCache, Code Cache…) found anywhere under Application Support. Never touches saved app data." = "Cache-style folders (Cache, GPUCache, Code Cache…) found anywhere under Application Support. Never touches saved app data.";
+"Cursor Database Backup" = "Cursor Database Backup";
+"state.vscdb.backup — a leftover backup file, always safe to remove." = "state.vscdb.backup — a leftover backup file, always safe to remove.";
+"Compact Cursor Database" = "Compact Cursor Database";
+"VACUUMs state.vscdb, reclaiming space from a known chat-history bloat bug. No data is lost." = "VACUUMs state.vscdb, reclaiming space from a known chat-history bloat bug. No data is lost.";
+"Quit Cursor first to compact its database" = "Quit Cursor first to compact its database";
+"Freed %@" = "Freed %@";
+"Scanning…" = "Scanning…";
+"Reclaimable: %@" = "Reclaimable: %@";
+"Tap to Confirm" = "Tap to Confirm";
+"Clean Now" = "Clean Now";
+"Cyclop needs Full Disk Access to clean system caches" = "Cyclop needs Full Disk Access to clean system caches";
+"Quit and reopen Cyclop after granting access." = "Quit and reopen Cyclop after granting access.";
+"Open Full Disk Access Settings" = "Open Full Disk Access Settings";
+"Memory glow" = "Memory glow";
+"Also glow from RAM used" = "Also glow from RAM used";
+"Same graph as Activity Monitor." = "Same graph as Activity Monitor.";
+"Yellow after a short hold. Red is immediate." = "Yellow after a short hold. Red is immediate.";
+"Waiting — yellow if this holds." = "Waiting — yellow if this holds.";
+"Graph is yellow. Notch stays dark until red." = "Graph is yellow. Notch stays dark until red.";
+"Notch stays dark until red." = "Notch stays dark until red.";
+"Preview glow" = "Preview glow";
+"Yellow at" = "Yellow at";
+"Red at" = "Red at";
+"Preview yellow" = "Preview yellow";
+"Preview red" = "Preview red";
+"Preview meeting" = "Preview meeting";
+"Jetsam" = "Pressure";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -17,6 +17,7 @@
 /* Вкладка настроек */
 "General" = "Общее";
 "Launch at Login" = "Запускать при входе";
+"Keep Awake with Lid Closed" = "Не спать с закрытой крышкой";
 "Screenshots" = "Скриншоты";
 "Save Clipboard Screenshots" = "Сохранять скриншоты из буфера";
 "Show Screenshots Folder" = "Показать папку скриншотов";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -12,6 +12,9 @@
 
 /* Меню-бар */
 "Open Panel" = "Открыть панель";
+"Settings…" = "Настройки…";
+"All Settings…" = "Все настройки…";
+"Notch glows only when the graph is red." = "Notch загорается только когда график красный.";
 "Quit" = "Выйти";
 
 /* Вкладка настроек */
@@ -24,6 +27,7 @@
 "Clear Screenshots Folder" = "Очистить папку снимков";
 "Clear Screenshots Folder (%@)" = "Очистить папку снимков (%@)";
 "Show Snippets File" = "Показать файл заготовок";
+"No usage cards enabled — turn some on in Settings" = "Нет карточек лимитов — включите их в Настройках";
 
 /* Полка */
 "Selected: %d" = "Выбрано: %d";
@@ -133,3 +137,54 @@
 "Skip" = "Пропуск";
 "Focus done — time for a break" = "Фокус закончен — пора на перерыв";
 "Break over — back to focus" = "Перерыв окончен — обратно к фокусу";
+
+/* Память: график давления как в «Активности», плюс очистка кэшей. */
+"Memory" = "Память";
+"Memory Pressure · Green" = "Давление памяти · зелёный";
+"Memory Pressure · Yellow" = "Давление памяти · жёлтый";
+"Memory Pressure · Red" = "Давление памяти · красный";
+"Running optimally." = "Всё работает нормально.";
+"Close unneeded tabs and quit unused apps." = "Закройте лишние вкладки и неиспользуемые приложения.";
+"The Mac is swapping. Close tabs, then clean caches below." = "Мак выгружает память на диск. Закройте вкладки, затем почистите кэши ниже.";
+"Swap" = "Swap";
+"Disk free" = "Свободно на диске";
+"Starts in 10 min" = "Начало через 10 мин";
+"App & System Caches" = "Кэши приложений и системы";
+"Everything in ~/Library/Caches — every app rebuilds this from scratch." = "Всё в ~/Library/Caches — приложения соберут заново сами.";
+"npm Package Cache" = "Кэш пакетов npm";
+"~/.npm — npm re-downloads packages as needed." = "~/.npm — npm скачает пакеты снова, когда понадобятся.";
+"CLI Tool Cache" = "Кэш CLI-инструментов";
+"~/.cache — shared cache folder used by many command-line dev tools." = "~/.cache — общий кэш многих консольных инструментов.";
+"pnpm Store" = "Хранилище pnpm";
+"Runs “pnpm store prune” to drop packages nothing references anymore." = "Запускает «pnpm store prune» — убирает пакеты, на которые никто не ссылается.";
+"Docker Unused Data" = "Неиспользуемые данные Docker";
+"Removes ALL unused images, containers, and volumes not currently in use — off by default, more destructive than the rest." = "Удаляет ВСЕ неиспользуемые образы, контейнеры и тома — по умолчанию выключено, жёстче остальных.";
+"App Cache Subfolders" = "Кэш-папки приложений";
+"Cache-style folders (Cache, GPUCache, Code Cache…) found anywhere under Application Support. Never touches saved app data." = "Папки вроде Cache, GPUCache, Code Cache в Application Support. Данные приложений не трогает.";
+"Cursor Database Backup" = "Резервная копия базы Cursor";
+"state.vscdb.backup — a leftover backup file, always safe to remove." = "state.vscdb.backup — лишний бэкап, его всегда безопасно удалить.";
+"Compact Cursor Database" = "Сжать базу Cursor";
+"VACUUMs state.vscdb, reclaiming space from a known chat-history bloat bug. No data is lost." = "VACUUM для state.vscdb — место от раздутой истории чатов. Данные не теряются.";
+"Quit Cursor first to compact its database" = "Сначала закройте Cursor, чтобы сжать его базу";
+"Freed %@" = "Освобождено %@";
+"Scanning…" = "Сканирование…";
+"Reclaimable: %@" = "Можно освободить: %@";
+"Tap to Confirm" = "Ещё раз для подтверждения";
+"Clean Now" = "Очистить";
+"Cyclop needs Full Disk Access to clean system caches" = "Cyclop нужен доступ к полному диску, чтобы чистить системные кэши";
+"Quit and reopen Cyclop after granting access." = "После выдачи доступа закройте Cyclop и откройте снова.";
+"Open Full Disk Access Settings" = "Открыть настройки полного диска";
+"Memory glow" = "Подсветка памяти";
+"Also glow from RAM used" = "Также от занятой RAM";
+"Same graph as Activity Monitor." = "Тот же график, что в «Активности».";
+"Yellow after a short hold. Red is immediate." = "Жёлтый после короткой паузы. Красный сразу.";
+"Waiting — yellow if this holds." = "Ждём — жёлтый, если не спадёт.";
+"Graph is yellow. Notch stays dark until red." = "График жёлтый. Notch загорится на красном.";
+"Notch stays dark until red." = "Notch загорится только на красном.";
+"Preview glow" = "Превью подсветки";
+"Yellow at" = "Жёлтый от";
+"Red at" = "Красный от";
+"Preview yellow" = "Превью жёлтого";
+"Preview red" = "Превью красного";
+"Preview meeting" = "Превью созвона";
+"Jetsam" = "Давление";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -98,3 +98,23 @@
 "Paste the script here" = "Вставьте сюда сценарий";
 "Ready" = "Готово";
 "Done" = "Готово";
+
+/* Вкладка лимитов — живые данные Claude через тот же OAuth-токен, что и Claude Code CLI. */
+"Usage" = "Лимиты";
+"5-hour window" = "5-часовое окно";
+"7-day window" = "7-дневное окно";
+"Extra usage" = "Доп. кредиты";
+"Not signed in to Claude" = "Не авторизовано в Claude";
+"Sign in with claude in Terminal,\nthen reopen this tab" = "Войдите через claude в Терминале\nи откройте вкладку заново";
+"Can't reach Claude" = "Не удаётся связаться с Claude";
+"No Codex sessions found yet" = "Пока нет сессий Codex";
+"%d-day window" = "%d-дневное окно";
+"%d-hour window" = "%d-часовое окно";
+"resets in %@" = "сброс через %@";
+"resets any moment" = "сброс с минуты на минуту";
+"as of %@ ago" = "данные %@ назад";
+"as of just now" = "данные только что";
+"Cursor Models" = "Модели Cursor";
+"Other Models" = "Другие модели";
+"Not signed in to Cursor" = "Не авторизовано в Cursor";
+"Can't reach Cursor" = "Не удаётся связаться с Cursor";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -98,3 +98,17 @@
 "Paste the script here" = "Вставьте сюда сценарий";
 "Ready" = "Готово";
 "Done" = "Готово";
+
+/* Помодоро */
+"Pomodoro" = "Помодоро";
+"Focus" = "Фокус";
+"Break" = "Перерыв";
+"Long Break" = "Длинный перерыв";
+"Classic" = "Классика";
+"Short" = "Короткий";
+"Long" = "Длинный";
+"Custom" = "Свой";
+"Reset" = "Сброс";
+"Skip" = "Пропуск";
+"Focus done — time for a break" = "Фокус закончен — пора на перерыв";
+"Break over — back to focus" = "Перерыв окончен — обратно к фокусу";

--- a/Scripts/bundle.sh
+++ b/Scripts/bundle.sh
@@ -44,6 +44,8 @@ cat > "$APP/Contents/Info.plist" <<PLIST
     <string>Cyclop показывает ближайшие встречи и кнопку подключения к ним.</string>
     <key>NSCalendarsUsageDescription</key>
     <string>Cyclop показывает ближайшие встречи и кнопку подключения к ним.</string>
+    <key>NSUserNotificationsUsageDescription</key>
+    <string>Cyclop напоминает о созвоне за десять минут и о конце помодоро.</string>
     <key>NSHumanReadableCopyright</key><string>MIT License</string>
 </dict>
 </plist>

--- a/Sources/Cyclop/App/AppDelegate.swift
+++ b/Sources/Cyclop/App/AppDelegate.swift
@@ -41,6 +41,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         toggle.target = self
         menu.addItem(toggle)
 
+        let settings = NSMenuItem(
+            title: localized("Settings…"),
+            action: #selector(openSettings),
+            keyEquivalent: ","
+        )
+        settings.target = self
+        menu.addItem(settings)
+
         // Sits next to the panel switch rather than in the Settings tab: it
         // changes what the panel shows, and it is the one people look for in a
         // hurry, with the camera already running.
@@ -86,6 +94,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     @objc private func togglePanel() {
         controller?.toggle()
+    }
+
+    @objc private func openSettings() {
+        controller?.openSettings()
     }
 
     /// Everything shown is re-read when the menu opens, not kept fresh in

--- a/Sources/Cyclop/Model/NotchViewModel.swift
+++ b/Sources/Cyclop/Model/NotchViewModel.swift
@@ -4,7 +4,7 @@ import Combine
 @MainActor
 final class NotchViewModel: ObservableObject {
     enum Tab: String, CaseIterable, Identifiable {
-        case media, shelf, clipboard, snippets, calendar, translate, notes, teleprompter, credits, pomodoro, settings
+        case media, shelf, clipboard, snippets, calendar, translate, notes, teleprompter, credits, pomodoro, memory, settings
         var id: String { rawValue }
 
         var symbol: String {
@@ -19,6 +19,7 @@ final class NotchViewModel: ObservableObject {
             case .teleprompter: return "text.viewfinder"
             case .credits: return "gauge"
             case .pomodoro: return "timer"
+            case .memory: return "memorychip"
             case .settings: return "gearshape.fill"
             }
         }
@@ -35,6 +36,7 @@ final class NotchViewModel: ObservableObject {
             case .teleprompter: return localized("Teleprompter")
             case .credits: return localized("Usage")
             case .pomodoro: return localized("Pomodoro")
+            case .memory: return localized("Memory")
             case .settings: return localized("Settings")
             }
         }
@@ -53,7 +55,7 @@ final class NotchViewModel: ObservableObject {
         /// past on the way to a track or a calendar, so it sits last,
         /// furthest from the tabs people actually rest on.
         static let leftRail: [Tab] = [.media, .shelf, .clipboard, .snippets, .calendar, .translate]
-        static let rightRail: [Tab] = [.notes, .teleprompter, .credits, .pomodoro, .settings]
+        static let rightRail: [Tab] = [.notes, .memory, .teleprompter, .credits, .pomodoro, .settings]
     }
 
     @Published var isOpen = false
@@ -80,6 +82,11 @@ final class NotchViewModel: ObservableObject {
                 codex.reload()
                 cursor.reload()
             }
+            if tab == .memory {
+                memory.setActive(true)
+                cleanup.scan()
+            }
+            if oldValue == .memory, tab != .memory { memory.setActive(false) }
             // Leaving the notes sweeps out the blank ones — they cost one
             // hover to recreate, and a trail of empty cards is the clutter a
             // scratchpad exists to avoid.
@@ -124,10 +131,16 @@ final class NotchViewModel: ObservableObject {
     let usage = ClaudeUsageStore()
     let codex = CodexUsageStore()
     let cursor = CursorUsageStore()
+    let usageProviders = UsageProviderSettings()
     let sleepManager = SleepManager()
     let pomodoro = PomodoroStore()
+    let memory = MemoryPressureStore()
+    let cleanup = CleanupStore()
     /// Shared by every pane that shows something worth not showing.
     let privacy = PrivacyMode()
+    /// Opens the full settings window. Set by the controller — the pane
+    /// cannot own a window of its own.
+    var onOpenFullSettings: (() -> Void)?
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -165,19 +178,121 @@ final class NotchViewModel: ObservableObject {
             media.objectWillChange,
             shelf.objectWillChange,
             clipboard.objectWillChange,
-            calendar.objectWillChange,
-            pomodoro.objectWillChange,
+            usageProviders.objectWillChange,
         ] {
             child
                 .sink { [weak self] _ in
                     guard let self else { return }
-                    // Pomodoro paints a rim on the collapsed island, so its
-                    // phase changes have to redraw the view while closed.
-                    guard self.isOpen || self.isDropTargeted || self.pomodoro.isRunning else { return }
+                    guard self.isOpen || self.isDropTargeted else { return }
                     self.objectWillChange.send()
                 }
                 .store(in: &cancellables)
         }
+        // These three paint the collapsed island: pomodoro's rim, memory
+        // pressure, the meeting glow. Their events are rare enough to
+        // redraw while closed — a 30 s calendar tick never reaches here
+        // because that timer is stopped with the panel.
+        for child in [
+            calendar.objectWillChange,
+            pomodoro.objectWillChange,
+            memory.objectWillChange,
+        ] {
+            child
+                .sink { [weak self] _ in self?.objectWillChange.send() }
+                .store(in: &cancellables)
+        }
+    }
+
+    /// Who owns the collapsed rim, if anyone.
+    ///
+    /// A meeting ten minutes out outranks memory, which outranks pomodoro:
+    /// a call is a deadline, yellow RAM is a hint, a focus session is a
+    /// choice already in progress.
+    enum CollapsedRim: Equatable {
+        case none
+        case meeting(pulsing: Bool)
+        case memoryWarn
+        case memoryCritical
+        case pomodoro(PomodoroStore.Phase)
+    }
+
+    var collapsedRim: CollapsedRim {
+        if rimPreview != .none { return rimPreview }
+        if calendar.approaching != nil {
+            return .meeting(pulsing: calendar.rimPulse)
+        }
+        switch memory.glowLevel {
+        case .critical: return .memoryCritical
+        case .warn: return .memoryWarn
+        case .normal: break
+        }
+        if let phase = pomodoro.collapsedRimPhase {
+            return .pomodoro(phase)
+        }
+        return .none
+    }
+
+    /// Settings preview — painted even while the panel is open.
+    @Published private(set) var rimPreview: CollapsedRim = .none
+    private var previewClear: DispatchWorkItem?
+    private var previewPulse: Timer?
+    private var previewPulseLeft = 0
+
+    func previewMemoryWarn() { holdPreview(.memoryWarn, seconds: 4) }
+    func previewMemoryCritical() { holdPreview(.memoryCritical, seconds: 4) }
+
+    func previewMeeting() {
+        cancelPreview()
+        previewPulseLeft = 6
+        rimPreview = .meeting(pulsing: true)
+        let timer = Timer(timeInterval: 0.4, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.tickPreviewPulse() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        previewPulse = timer
+    }
+
+    func reloadUsage(force: Bool = false) {
+        usage.reload(force: force)
+        cursor.reload(force: force)
+        codex.reload()
+    }
+
+    private func holdPreview(_ rim: CollapsedRim, seconds: TimeInterval) {
+        cancelPreview()
+        rimPreview = rim
+        let work = DispatchWorkItem { [weak self] in
+            self?.rimPreview = .none
+        }
+        previewClear = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: work)
+    }
+
+    private func tickPreviewPulse() {
+        guard previewPulseLeft > 0 else {
+            previewPulse?.invalidate()
+            previewPulse = nil
+            rimPreview = .meeting(pulsing: false)
+            let work = DispatchWorkItem { [weak self] in
+                self?.rimPreview = .none
+            }
+            previewClear = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: work)
+            return
+        }
+        previewPulseLeft -= 1
+        if case .meeting(let pulsing) = rimPreview {
+            rimPreview = .meeting(pulsing: !pulsing)
+        }
+    }
+
+    private func cancelPreview() {
+        previewClear?.cancel()
+        previewClear = nil
+        previewPulse?.invalidate()
+        previewPulse = nil
+        previewPulseLeft = 0
+        rimPreview = .none
     }
 
     /// Body this tab takes when open — asked whether it is open yet or not.
@@ -198,7 +313,9 @@ final class NotchViewModel: ObservableObject {
     var openBodySize: CGSize {
         switch tab {
         case .teleprompter: geometry.tallExpandedSize
-        case .credits: geometry.creditsExpandedSize
+        case .credits:
+            geometry.creditsExpandedSize(forRows: UsageGrid.rows(for: usageProviders.enabled.count))
+        case .memory: geometry.toolsExpandedSize
         default: geometry.expandedSize
         }
     }
@@ -234,6 +351,7 @@ final class NotchViewModel: ObservableObject {
         // Only picks up where it left off if access was granted earlier; it
         // never prompts on its own.
         calendar.start()
+        memory.start()
 
         // Screenshots reach the shelf through here whether they were taken on
         // this Mac or on a phone: a copy made on the phone arrives in the same
@@ -255,6 +373,8 @@ final class NotchViewModel: ObservableObject {
         media.stop()
         clipboard.stop()
         calendar.stop()
+        memory.stop()
+        cancelPreview()
         // Whatever was typed makes it to disk even when quitting mid-thought.
         notes.flush()
         sleepManager.stop()

--- a/Sources/Cyclop/Model/NotchViewModel.swift
+++ b/Sources/Cyclop/Model/NotchViewModel.swift
@@ -4,7 +4,7 @@ import Combine
 @MainActor
 final class NotchViewModel: ObservableObject {
     enum Tab: String, CaseIterable, Identifiable {
-        case media, shelf, clipboard, snippets, calendar, translate, notes, teleprompter, settings
+        case media, shelf, clipboard, snippets, calendar, translate, notes, teleprompter, pomodoro, settings
         var id: String { rawValue }
 
         var symbol: String {
@@ -17,6 +17,7 @@ final class NotchViewModel: ObservableObject {
             case .translate: return "translate"
             case .notes: return "note.text"
             case .teleprompter: return "text.viewfinder"
+            case .pomodoro: return "timer"
             case .settings: return "gearshape.fill"
             }
         }
@@ -31,6 +32,7 @@ final class NotchViewModel: ObservableObject {
             case .translate: return localized("Translate")
             case .notes: return localized("Notes")
             case .teleprompter: return localized("Teleprompter")
+            case .pomodoro: return localized("Pomodoro")
             case .settings: return localized("Settings")
             }
         }
@@ -49,7 +51,7 @@ final class NotchViewModel: ObservableObject {
         /// past on the way to a track or a calendar, so it sits last,
         /// furthest from the tabs people actually rest on.
         static let leftRail: [Tab] = [.media, .shelf, .clipboard, .snippets, .calendar, .translate]
-        static let rightRail: [Tab] = [.notes, .teleprompter, .settings]
+        static let rightRail: [Tab] = [.notes, .teleprompter, .pomodoro, .settings]
     }
 
     @Published var isOpen = false
@@ -110,6 +112,7 @@ final class NotchViewModel: ObservableObject {
     let snippets: SnippetStore
     let notes: NoteStore
     let teleprompter: TeleprompterStore
+    let pomodoro = PomodoroStore()
     /// Shared by every pane that shows something worth not showing.
     let privacy = PrivacyMode()
 
@@ -150,10 +153,14 @@ final class NotchViewModel: ObservableObject {
             shelf.objectWillChange,
             clipboard.objectWillChange,
             calendar.objectWillChange,
+            pomodoro.objectWillChange,
         ] {
             child
                 .sink { [weak self] _ in
-                    guard let self, self.isOpen || self.isDropTargeted else { return }
+                    guard let self else { return }
+                    // Pomodoro paints a rim on the collapsed island, so its
+                    // phase changes have to redraw the view while closed.
+                    guard self.isOpen || self.isDropTargeted || self.pomodoro.isRunning else { return }
                     self.objectWillChange.send()
                 }
                 .store(in: &cancellables)

--- a/Sources/Cyclop/Model/NotchViewModel.swift
+++ b/Sources/Cyclop/Model/NotchViewModel.swift
@@ -4,7 +4,7 @@ import Combine
 @MainActor
 final class NotchViewModel: ObservableObject {
     enum Tab: String, CaseIterable, Identifiable {
-        case media, shelf, clipboard, snippets, calendar, translate, notes, teleprompter, settings
+        case media, shelf, clipboard, snippets, calendar, translate, notes, teleprompter, credits, settings
         var id: String { rawValue }
 
         var symbol: String {
@@ -17,6 +17,7 @@ final class NotchViewModel: ObservableObject {
             case .translate: return "translate"
             case .notes: return "note.text"
             case .teleprompter: return "text.viewfinder"
+            case .credits: return "gauge"
             case .settings: return "gearshape.fill"
             }
         }
@@ -31,6 +32,7 @@ final class NotchViewModel: ObservableObject {
             case .translate: return localized("Translate")
             case .notes: return localized("Notes")
             case .teleprompter: return localized("Teleprompter")
+            case .credits: return localized("Usage")
             case .settings: return localized("Settings")
             }
         }
@@ -49,7 +51,7 @@ final class NotchViewModel: ObservableObject {
         /// past on the way to a track or a calendar, so it sits last,
         /// furthest from the tabs people actually rest on.
         static let leftRail: [Tab] = [.media, .shelf, .clipboard, .snippets, .calendar, .translate]
-        static let rightRail: [Tab] = [.notes, .teleprompter, .settings]
+        static let rightRail: [Tab] = [.notes, .teleprompter, .credits, .settings]
     }
 
     @Published var isOpen = false
@@ -69,6 +71,13 @@ final class NotchViewModel: ObservableObject {
             // prompt. It is asked here, with the shelf on screen, rather than
             // at launch with nothing to explain it.
             if tab == .shelf { shelf.refreshFromDisk() }
+            // Another tool's cache, refreshed on its own clock — read on the
+            // way in, same as the snippets file.
+            if tab == .credits {
+                usage.reload()
+                codex.reload()
+                cursor.reload()
+            }
             // Leaving the notes sweeps out the blank ones — they cost one
             // hover to recreate, and a trail of empty cards is the clutter a
             // scratchpad exists to avoid.
@@ -110,6 +119,9 @@ final class NotchViewModel: ObservableObject {
     let snippets: SnippetStore
     let notes: NoteStore
     let teleprompter: TeleprompterStore
+    let usage = ClaudeUsageStore()
+    let codex = CodexUsageStore()
+    let cursor = CursorUsageStore()
     /// Shared by every pane that shows something worth not showing.
     let privacy = PrivacyMode()
 
@@ -169,12 +181,18 @@ final class NotchViewModel: ObservableObject {
     /// that step the collapsed size and leave the whole body drawn but deaf to
     /// the pointer.
     ///
-    /// One tab is taller than the rest. Type large enough to read at a glance
-    /// leaves room for two lines in the standard body, and two lines is not a
-    /// teleprompter — it is a countdown. The extra height buys the paragraph
-    /// the reader needs to see coming.
+    /// Two tabs ask for more than the standard body. Type large enough to
+    /// read at a glance leaves room for two lines in the standard body, and
+    /// two lines is not a teleprompter — it is a countdown. The extra height
+    /// buys the paragraph the reader needs to see coming. Usage asks for
+    /// less than that, just enough that its two rows of cards are not
+    /// squeezed into the same body a one-line agenda gets by on.
     var openBodySize: CGSize {
-        tab == .teleprompter ? geometry.tallExpandedSize : geometry.expandedSize
+        switch tab {
+        case .teleprompter: geometry.tallExpandedSize
+        case .credits: geometry.creditsExpandedSize
+        default: geometry.expandedSize
+        }
     }
 
     /// Size of the visible body for the current state.

--- a/Sources/Cyclop/Model/NotchViewModel.swift
+++ b/Sources/Cyclop/Model/NotchViewModel.swift
@@ -110,6 +110,7 @@ final class NotchViewModel: ObservableObject {
     let snippets: SnippetStore
     let notes: NoteStore
     let teleprompter: TeleprompterStore
+    let sleepManager = SleepManager()
     /// Shared by every pane that shows something worth not showing.
     let privacy = PrivacyMode()
 
@@ -231,6 +232,7 @@ final class NotchViewModel: ObservableObject {
         calendar.stop()
         // Whatever was typed makes it to disk even when quitting mid-thought.
         notes.flush()
+        sleepManager.stop()
     }
 
     /// A screenshot that arrived on its own — copied elsewhere, or synced

--- a/Sources/Cyclop/Model/UsageProviders.swift
+++ b/Sources/Cyclop/Model/UsageProviders.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+enum UsageProvider: String, CaseIterable, Identifiable {
+    case claude, codex, cursor
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .claude: "Claude"
+        case .codex: "Codex"
+        case .cursor: "Cursor"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .claude: "sparkle"
+        case .codex: "chevron.left.forwardslash.chevron.right"
+        case .cursor: "cursorarrow"
+        }
+    }
+}
+
+enum UsageGrid {
+    static let rowSpacing: CGFloat = 8
+
+    /// Width grows first: 1 → one card, 2 → two across, 3 → three across,
+    /// 4 → 2×2. `Int(sqrt(3))` is 1, so three providers stay on a single row.
+    static func rows(for count: Int) -> Int {
+        guard count > 1 else { return max(count, 1) }
+        return max(Int(Double(count).squareRoot()), 1)
+    }
+
+    static func columns(for count: Int) -> Int {
+        guard count > 0 else { return 1 }
+        return Int((Double(count) / Double(rows(for: count))).rounded(.up))
+    }
+}
+
+@MainActor
+final class UsageProviderSettings: ObservableObject {
+    private static let key = "usageProviders.disabled"
+
+    @Published private(set) var disabled: Set<String>
+
+    init() {
+        let stored = UserDefaults.standard.stringArray(forKey: Self.key) ?? []
+        disabled = Set(stored)
+    }
+
+    func isEnabled(_ provider: UsageProvider) -> Bool {
+        !disabled.contains(provider.rawValue)
+    }
+
+    var enabled: [UsageProvider] {
+        UsageProvider.allCases.filter(isEnabled)
+    }
+
+    func setEnabled(_ provider: UsageProvider, _ on: Bool) {
+        if on {
+            disabled.remove(provider.rawValue)
+        } else {
+            disabled.insert(provider.rawValue)
+        }
+        UserDefaults.standard.set(Array(disabled).sorted(), forKey: Self.key)
+    }
+}

--- a/Sources/Cyclop/Notch/NotchController.swift
+++ b/Sources/Cyclop/Notch/NotchController.swift
@@ -7,6 +7,7 @@ final class NotchController {
     private var panel: NotchPanel?
     private var rootView: NotchRootView?
     private var viewModel: NotchViewModel?
+    private var settingsWindow: SettingsWindowController?
     private let pointer = PointerWatcher()
     private var closeActiveRectWork: DispatchWorkItem?
     private var cancellables = Set<AnyCancellable>()
@@ -79,8 +80,23 @@ final class NotchController {
     func teardown() {
         pointer.stop()
         viewModel?.stop()
+        settingsWindow?.close()
+        settingsWindow = nil
         panel?.acceptsKeyboard = false
         panel?.orderOut(nil)
+    }
+
+    /// Compact toggles stay in the notch; steppers, previews and folders
+    /// need a real window — and the collapsed island has to be visible for
+    /// the glow previews to mean anything.
+    func openSettings() {
+        guard let vm = viewModel else { return }
+        setOpen(false)
+        pointer.setInside(false)
+        if settingsWindow == nil {
+            settingsWindow = SettingsWindowController()
+        }
+        settingsWindow?.present(vm: vm)
     }
 
     func toggle() {
@@ -105,6 +121,9 @@ final class NotchController {
         viewModel = nil
         build()
         if let previousTab { viewModel?.tab = previousTab }
+        if settingsWindow?.window?.isVisible == true, let vm = viewModel {
+            settingsWindow?.present(vm: vm)
+        }
     }
 
     private func build() {
@@ -228,6 +247,8 @@ final class NotchController {
             }
             .store(in: &cancellables)
 
+        vm.onOpenFullSettings = { [weak self] in self?.openSettings() }
+
         vm.start()
 
         // A rebuilt panel starts closed. If the pointer is already sitting on
@@ -282,6 +303,8 @@ final class NotchController {
             withAnimation(Theme.openAnimation) { vm.isOpen = true }
             vm.media.setActive(true)
             vm.calendar.setActive(true)
+            if vm.tab == .memory { vm.memory.setActive(true) }
+            if vm.tab == .credits { vm.reloadUsage(force: true) }
         } else {
             // The keyboard goes first and the fold goes second — one run-loop
             // pass apart, never together. Dropped in the same pass, resigning
@@ -315,6 +338,7 @@ final class NotchController {
         withAnimation(Theme.openAnimation) { vm.isOpen = false }
         vm.media.setActive(false)
         vm.calendar.setActive(false)
+        vm.memory.setActive(false)
         // Shrink only once the panel has finished collapsing. Doing it
         // while it is still visibly there would leave a window in which
         // clicks land on whatever is behind the panel.

--- a/Sources/Cyclop/Notch/NotchGeometry.swift
+++ b/Sources/Cyclop/Notch/NotchGeometry.swift
@@ -37,10 +37,18 @@ struct NotchGeometry {
     var tallExpandedSize: CGSize {
         CGSize(width: expandedSize.width, height: Self.tallBodyHeight)
     }
+
+    /// Body for the usage tab: two rows of cards need more headroom than a
+    /// list does, short of the teleprompter's full paragraph.
+    static let creditsBodyHeight: CGFloat = 330
+    var creditsExpandedSize: CGSize {
+        CGSize(width: expandedSize.width, height: Self.creditsBodyHeight)
+    }
+
     /// Tallest body any tab can ask for. The window is cut to this once and
     /// never resized: it is transparent outside the visible panel, and what is
     /// clickable is decided separately by the active rect.
-    var maxBodyHeight: CGFloat { max(expandedSize.height, Self.tallBodyHeight) }
+    var maxBodyHeight: CGFloat { max(expandedSize.height, Self.tallBodyHeight, Self.creditsBodyHeight) }
 
     /// What the body has left for content on an ordinary tab, once the header
     /// and the padding beneath are taken out.

--- a/Sources/Cyclop/Notch/NotchGeometry.swift
+++ b/Sources/Cyclop/Notch/NotchGeometry.swift
@@ -38,17 +38,32 @@ struct NotchGeometry {
         CGSize(width: expandedSize.width, height: Self.tallBodyHeight)
     }
 
-    /// Body for the usage tab: two rows of cards need more headroom than a
-    /// list does, short of the teleprompter's full paragraph.
-    static let creditsBodyHeight: CGFloat = 330
-    var creditsExpandedSize: CGSize {
-        CGSize(width: expandedSize.width, height: Self.creditsBodyHeight)
+    /// One Usage card row — Claude's extra-usage line is the tallest.
+    static let creditsRowHeight: CGFloat = 165
+    /// Header plus padding under the grid. 400 = chrome + 2×165 + 1×8.
+    static let creditsChrome: CGFloat = tallBodyHeight - 2 * creditsRowHeight - UsageGrid.rowSpacing
+    /// Memory / Settings — cleanup list needs this much, short of teleprompter.
+    static let toolsBodyHeight: CGFloat = 330
+
+    func creditsBodyHeight(forRows rows: Int) -> CGFloat {
+        let rows = max(rows, 1)
+        let height = Self.creditsChrome + CGFloat(rows) * Self.creditsRowHeight
+            + CGFloat(rows - 1) * UsageGrid.rowSpacing
+        return min(height, Self.tallBodyHeight)
+    }
+
+    func creditsExpandedSize(forRows rows: Int) -> CGSize {
+        CGSize(width: expandedSize.width, height: creditsBodyHeight(forRows: rows))
+    }
+
+    var toolsExpandedSize: CGSize {
+        CGSize(width: expandedSize.width, height: Self.toolsBodyHeight)
     }
 
     /// Tallest body any tab can ask for. The window is cut to this once and
     /// never resized: it is transparent outside the visible panel, and what is
     /// clickable is decided separately by the active rect.
-    var maxBodyHeight: CGFloat { max(expandedSize.height, Self.tallBodyHeight, Self.creditsBodyHeight) }
+    var maxBodyHeight: CGFloat { max(expandedSize.height, Self.tallBodyHeight, Self.toolsBodyHeight) }
 
     /// What the body has left for content on an ordinary tab, once the header
     /// and the padding beneath are taken out.
@@ -70,8 +85,8 @@ struct NotchGeometry {
     /// Rounded down rather than to the nearest point: a rail that asks for
     /// more than it is given should visibly yield, not overflow by a
     /// fraction that clips it.
-    var railIconHeight: CGFloat {
-        let icons = CGFloat(NotchViewModel.Tab.leftRail.count)
+    func railIconHeight(forIconCount count: Int) -> CGFloat {
+        let icons = CGFloat(max(count, 1))
         let available = expandedSize.height - notchSize.height - Self.bodyBottomPadding
         let ceiling = (available - (icons - 1) * Self.railSpacing) / icons
         return min(24, ceiling).rounded(.down)

--- a/Sources/Cyclop/Services/CalendarStore.swift
+++ b/Sources/Cyclop/Services/CalendarStore.swift
@@ -1,5 +1,6 @@
 import AppKit
 import EventKit
+import UserNotifications
 
 /// Today's meetings, and the link that joins the next one.
 ///
@@ -44,6 +45,11 @@ final class CalendarStore: ObservableObject {
     @Published private(set) var meetings: [Meeting] = []
     /// Recomputed on a timer so the countdown in the header stays honest.
     @Published private(set) var now = Date()
+    /// Next meeting inside the ten-minute window, not yet started.
+    /// Drives the collapsed neon rim; `nil` the rest of the time.
+    @Published private(set) var approaching: Meeting?
+    /// Bright half of the "blink a couple of times" cycle.
+    @Published private(set) var rimPulse = false
 
     private let store = EKEventStore()
     private var timer: Timer?
@@ -52,6 +58,14 @@ final class CalendarStore: ObservableObject {
     /// keeps the countdown honest and drops meetings as they end — so it runs
     /// exactly while there are eyes.
     private var isActive = false
+    /// One-shot: fire when the next meeting enters the ten-minute window.
+    /// Cheap while collapsed — no polling, just a deadline.
+    private var alertWork: DispatchWorkItem?
+    private var pulseTimer: Timer?
+    private var pulseTicksLeft = 0
+    private var announcedIds = Set<String>()
+    private var askedForNotifications = false
+    private static let approachingWindow: TimeInterval = 10 * 60
     /// A day-long horizon leaves the tab empty every evening, which is exactly
     /// when one wonders what tomorrow looks like. A week is still glanceable
     /// because only the next meeting gets the large treatment.
@@ -77,6 +91,7 @@ final class CalendarStore: ObservableObject {
 
     func stop() {
         stopTimer()
+        cancelMeetingAlert()
         if let observer { NotificationCenter.default.removeObserver(observer) }
         observer = nil
     }
@@ -117,6 +132,7 @@ final class CalendarStore: ObservableObject {
                 self.observe()
                 self.reload()
                 if self.isActive { self.startTimer() }
+                self.scheduleMeetingAlert()
             }
         }
     }
@@ -185,7 +201,107 @@ final class CalendarStore: ObservableObject {
         // Drop finished meetings without a full refetch.
         if meetings.contains(where: { $0.end <= now }) {
             meetings.removeAll { $0.end <= now }
+            announcedIds = announcedIds.intersection(Set(meetings.map(\.id)))
         }
+        considerAlerts()
+    }
+
+    // MARK: - Meeting glow
+
+    /// Arms a deadline for the next meeting's ten-minute mark. The 30 s
+    /// countdown timer still sleeps while the panel is closed; this is the
+    /// one wake-up the collapsed rim is allowed.
+    private func scheduleMeetingAlert() {
+        alertWork?.cancel()
+        alertWork = nil
+        guard access == .granted else {
+            approaching = nil
+            return
+        }
+        guard let next, !next.isRunning else {
+            approaching = nil
+            return
+        }
+        let delay = next.start.addingTimeInterval(-Self.approachingWindow).timeIntervalSinceNow
+        if delay <= 0 {
+            considerAlerts()
+            return
+        }
+        approaching = nil
+        let work = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated { self?.considerAlerts() }
+        }
+        alertWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    private func considerAlerts() {
+        guard let next, !next.isRunning else {
+            approaching = nil
+            return
+        }
+        let until = next.start.timeIntervalSinceNow
+        guard until > 0, until <= Self.approachingWindow else {
+            approaching = nil
+            return
+        }
+        approaching = next
+        guard !announcedIds.contains(next.id) else { return }
+        announcedIds.insert(next.id)
+        announceMeeting(next)
+        startRimPulse()
+    }
+
+    private func startRimPulse() {
+        pulseTimer?.invalidate()
+        pulseTicksLeft = 6
+        rimPulse = true
+        let timer = Timer(timeInterval: 0.4, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.tickPulse() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        pulseTimer = timer
+    }
+
+    private func tickPulse() {
+        guard pulseTicksLeft > 0 else {
+            pulseTimer?.invalidate()
+            pulseTimer = nil
+            rimPulse = false
+            return
+        }
+        pulseTicksLeft -= 1
+        rimPulse.toggle()
+    }
+
+    private func cancelMeetingAlert() {
+        alertWork?.cancel()
+        alertWork = nil
+        pulseTimer?.invalidate()
+        pulseTimer = nil
+        pulseTicksLeft = 0
+        rimPulse = false
+        approaching = nil
+    }
+
+    private func announceMeeting(_ meeting: Meeting) {
+        requestNotificationsIfNeeded()
+        let content = UNMutableNotificationContent()
+        content.title = meeting.title
+        content.body = localized("Starts in 10 min")
+        content.sound = .default
+        let request = UNNotificationRequest(
+            identifier: "meeting.\(meeting.id)",
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+    }
+
+    private func requestNotificationsIfNeeded() {
+        guard !askedForNotifications else { return }
+        askedForNotifications = true
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
     }
 
     // MARK: - Loading
@@ -202,6 +318,8 @@ final class CalendarStore: ObservableObject {
         guard !calendars.isEmpty else {
             meetings = []
             now = Date()
+            approaching = nil
+            scheduleMeetingAlert()
             return
         }
         let start = Date()
@@ -226,6 +344,7 @@ final class CalendarStore: ObservableObject {
                 )
             }
         now = Date()
+        scheduleMeetingAlert()
     }
 
     /// Calendars for the status-bar picker (#36), each labelled with the pick

--- a/Sources/Cyclop/Services/ClaudeUsageStore.swift
+++ b/Sources/Cyclop/Services/ClaudeUsageStore.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Security
+
+/// One rolling limit window — Claude Code tracks a five-hour and a seven-day
+/// one side by side.
+struct ClaudeUsageWindow: Decodable {
+    let utilization: Double?
+    let resetsAt: Date?
+}
+
+/// Pay-as-you-go credits spent once the plan's own windows run out. Absent on
+/// plans that never turned it on, which is why every field here is optional.
+struct ClaudeExtraUsage: Decodable {
+    let isEnabled: Bool
+    let utilization: Double?
+    let currency: String?
+    /// `used_credits` / `monthly_limit` arrive as minor units — cents, not
+    /// euros — same idea as Stripe's `amount_minor`. Divided through once
+    /// here so nothing downstream has to remember the scale.
+    private let usedCredits: Double?
+    private let monthlyLimit: Double?
+    private let decimalPlaces: Int?
+
+    var used: Double? { usedCredits.map { $0 / scale } }
+    var limit: Double? { monthlyLimit.map { $0 / scale } }
+    private var scale: Double { pow(10, Double(decimalPlaces ?? 2)) }
+}
+
+struct ClaudeUsageSnapshot: Decodable {
+    let fiveHour: ClaudeUsageWindow
+    let sevenDay: ClaudeUsageWindow
+    let extraUsage: ClaudeExtraUsage?
+}
+
+/// Claude's own numbers, fetched the same way the Claude Code CLI's status
+/// line does: the OAuth token it already stored at login — Keychain first,
+/// its credentials file as a fallback — sent to the account's own usage
+/// endpoint. No login of Cyclop's own, no third-party plugin to depend on;
+/// the token is one Claude Code already put on this Mac.
+///
+/// Re-fetched on every visit to the tab, like `SnippetStore.reload()` re-reads
+/// its file — except the source here is a live endpoint, not a file, so a
+/// short-lived cache guards against a network round trip on every hover.
+@MainActor
+final class ClaudeUsageStore: ObservableObject {
+    @Published private(set) var snapshot: ClaudeUsageSnapshot?
+    /// True once a fetch has been tried and found no token at all — signed
+    /// out is a different message than "Claude did not answer".
+    @Published private(set) var noCredentials = false
+    /// True once a fetch has been tried and failed while a token was found —
+    /// offline, or Claude's endpoint is unhappy.
+    @Published private(set) var unreachable = false
+
+    private var lastFetch: Date?
+    /// Long enough that switching tabs back and forth does not hammer the
+    /// endpoint; short enough that a number just spent shows up promptly.
+    private static let minRefetchInterval: TimeInterval = 20
+
+    func reload() {
+        if let lastFetch, Date().timeIntervalSince(lastFetch) < Self.minRefetchInterval { return }
+        lastFetch = Date()
+        Task { await fetch() }
+    }
+
+    private func fetch() async {
+        guard let token = Self.token() else {
+            noCredentials = true
+            unreachable = false
+            return
+        }
+        guard let fresh = await Self.fetchLive(token: token) else {
+            unreachable = true
+            noCredentials = false
+            return
+        }
+        snapshot = fresh
+        noCredentials = false
+        unreachable = false
+    }
+
+    /// `security find-generic-password`'s own target, read straight from the
+    /// Keychain API instead of shelling out to it. Falls back to the plain
+    /// file Claude Code writes when Keychain has nothing — some installs use
+    /// one, some the other.
+    private static func token() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "Claude Code-credentials",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        if SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+           let data = item as? Data,
+           let token = extractAccessToken(data) {
+            return token
+        }
+        let credentialsFile = FileManager.default.homeDirectoryForCurrentUser
+            .appending(path: ".claude/.credentials.json")
+        guard let data = try? Data(contentsOf: credentialsFile) else { return nil }
+        return extractAccessToken(data)
+    }
+
+    private static func extractAccessToken(_ data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        if let oauth = json["claudeAiOauth"] as? [String: Any], let token = oauth["accessToken"] as? String {
+            return token
+        }
+        return json["accessToken"] as? String
+    }
+
+    /// Same request the status line makes: zero LLM tokens spent, five
+    /// seconds to answer or it is treated as unreachable.
+    private static func fetchLive(token: String) async -> ClaudeUsageSnapshot? {
+        var request = URLRequest(url: URL(string: "https://api.anthropic.com/api/oauth/usage")!)
+        request.timeoutInterval = 5
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            return nil
+        }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let string = try container.decode(String.self)
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            guard let date = formatter.date(from: string) else {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Bad date: \(string)")
+            }
+            return date
+        }
+        return try? decoder.decode(ClaudeUsageSnapshot.self, from: data)
+    }
+}

--- a/Sources/Cyclop/Services/ClaudeUsageStore.swift
+++ b/Sources/Cyclop/Services/ClaudeUsageStore.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Security
 
 /// One rolling limit window — Claude Code tracks a five-hour and a seven-day
 /// one side by side.
@@ -56,8 +55,8 @@ final class ClaudeUsageStore: ObservableObject {
     /// endpoint; short enough that a number just spent shows up promptly.
     private static let minRefetchInterval: TimeInterval = 20
 
-    func reload() {
-        if let lastFetch, Date().timeIntervalSince(lastFetch) < Self.minRefetchInterval { return }
+    func reload(force: Bool = false) {
+        if !force, let lastFetch, Date().timeIntervalSince(lastFetch) < Self.minRefetchInterval { return }
         lastFetch = Date()
         Task { await fetch() }
     }
@@ -68,37 +67,45 @@ final class ClaudeUsageStore: ObservableObject {
             unreachable = false
             return
         }
-        guard let fresh = await Self.fetchLive(token: token) else {
-            unreachable = true
+        if let fresh = await Self.fetchLive(token: token) {
+            snapshot = fresh
             noCredentials = false
+            unreachable = false
             return
         }
-        snapshot = fresh
+        UsageTokenCache.clearClaude()
+        if let retry = Self.token(), retry != token,
+           let fresh = await Self.fetchLive(token: retry) {
+            snapshot = fresh
+            noCredentials = false
+            unreachable = false
+            return
+        }
+        unreachable = true
         noCredentials = false
-        unreachable = false
     }
 
-    /// `security find-generic-password`'s own target, read straight from the
-    /// Keychain API instead of shelling out to it. Falls back to the plain
-    /// file Claude Code writes when Keychain has nothing — some installs use
-    /// one, some the other.
+    /// Claude Code's file first (no dialog), then a silent Keychain read,
+    /// then Cyclop's own cache, then one prompt that is cached afterwards.
     private static func token() -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: "Claude Code-credentials",
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        var item: CFTypeRef?
-        if SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
-           let data = item as? Data,
-           let token = extractAccessToken(data) {
+        let file = FileManager.default.homeDirectoryForCurrentUser
+            .appending(path: ".claude/.credentials.json")
+        if let data = try? Data(contentsOf: file), let token = extractAccessToken(data) {
+            UsageTokenCache.storeClaude(token)
             return token
         }
-        let credentialsFile = FileManager.default.homeDirectoryForCurrentUser
-            .appending(path: ".claude/.credentials.json")
-        guard let data = try? Data(contentsOf: credentialsFile) else { return nil }
-        return extractAccessToken(data)
+        if let data = UsageTokenCache.keychain(service: "Claude Code-credentials", allowPrompt: false),
+           let token = extractAccessToken(data) {
+            UsageTokenCache.storeClaude(token)
+            return token
+        }
+        if let cached = UsageTokenCache.claude { return cached }
+        if let data = UsageTokenCache.keychain(service: "Claude Code-credentials", allowPrompt: true),
+           let token = extractAccessToken(data) {
+            UsageTokenCache.storeClaude(token)
+            return token
+        }
+        return nil
     }
 
     private static func extractAccessToken(_ data: Data) -> String? {

--- a/Sources/Cyclop/Services/CleanupStore.swift
+++ b/Sources/Cyclop/Services/CleanupStore.swift
@@ -1,0 +1,410 @@
+import AppKit
+import Foundation
+
+/// One line item on the Clean tab: a fixed, hand-picked cache location, how
+/// to size it, and how to remove it. Kept data-driven so a new target is one
+/// array entry, not a new code path through the store or the pane.
+struct CleanupTarget: Identifiable {
+    enum Kind {
+        /// Empty everything inside a folder; the folder itself stays.
+        case wholeFolderContents
+        /// Delete one exact file.
+        case exactFile
+        /// Delete each directory `resolve()` returns, whole — used for the
+        /// allow-listed cache-folder scan, where the resolver itself finds
+        /// the leaves and this just removes them.
+        case exactDirectories
+        /// Run a Process command; nothing to size ahead of time.
+        case shellCommand(executable: String, arguments: [String])
+        /// VACUUM a sqlite database in place via the `sqlite3` CLI.
+        case sqliteVacuum
+    }
+
+    let id: String
+    let title: String
+    let description: String
+    let kind: Kind
+    let defaultOn: Bool
+    /// Cheap check — PATH lookups, file existence, one quick process launch.
+    /// False hides the row entirely (e.g. pnpm not installed).
+    let isAvailable: () -> Bool
+    /// A reason to show in place of the toggle when the row is visible but
+    /// the action itself is currently blocked (e.g. Cursor is running).
+    let isBlocked: () -> String?
+    /// Paths this target acts on. Unused for `.shellCommand`.
+    let resolve: () -> [URL]
+}
+
+/// Runtime state for one target — the static definition plus what scanning
+/// found and whether the user has it checked.
+struct CleanupItemState: Identifiable {
+    var id: String { target.id }
+    let target: CleanupTarget
+    var isEnabled: Bool
+    /// Bytes it would reclaim, or nil when unsizable ahead of time
+    /// (`.shellCommand` targets — the row shows "–" instead).
+    var size: Int64?
+    var blockedReason: String?
+}
+
+/// Scans the fixed cleanup targets, lets the user pick which to run, and
+/// deletes only those — the Clean tab's backing store.
+@MainActor
+final class CleanupStore: ObservableObject {
+    @Published private(set) var items: [CleanupItemState] = []
+    @Published private(set) var isScanning = false
+    @Published private(set) var isCleaning = false
+    @Published private(set) var lastFreed: Int64?
+    @Published private(set) var fullDiskAccessOK = true
+
+    private static let flippedKey = "cleanup.flippedTargets"
+    /// Ids whose on/off state differs from `target.defaultOn` — only the
+    /// exceptions are stored, since most targets keep their default forever.
+    private var flipped: Set<String>
+
+    init() {
+        flipped = Set(UserDefaults.standard.stringArray(forKey: Self.flippedKey) ?? [])
+    }
+
+    var totalReclaimable: Int64 {
+        items.filter { $0.isEnabled && $0.blockedReason == nil }.reduce(0) { $0 + ($1.size ?? 0) }
+    }
+
+    func isEnabled(_ target: CleanupTarget) -> Bool {
+        flipped.contains(target.id) ? !target.defaultOn : target.defaultOn
+    }
+
+    func setEnabled(_ id: String, _ on: Bool) {
+        guard let index = items.firstIndex(where: { $0.target.id == id }) else { return }
+        let target = items[index].target
+        if on == target.defaultOn {
+            flipped.remove(id)
+        } else {
+            flipped.insert(id)
+        }
+        UserDefaults.standard.set(Array(flipped).sorted(), forKey: Self.flippedKey)
+        items[index].isEnabled = on
+    }
+
+    func openFullDiskAccessSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles") else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    func scan() {
+        guard !isScanning, !isCleaning else { return }
+        Task { await performScan() }
+    }
+
+    /// A harmless probe: reading the user's own Caches folder needs Full
+    /// Disk Access on some systems and never does on others, but either way
+    /// it is the cheapest stand-in for "can Clean Now actually delete
+    /// anything", asked before the button is pressed rather than after.
+    /// Run off the main thread — same reasoning `SettingsPane.refreshUsage`
+    /// gives for not walking a folder on the thread the panel lives on.
+    private nonisolated static func probeFullDiskAccess() -> Bool {
+        let caches = home.appendingPathComponent("Library/Caches", isDirectory: true)
+        return (try? FileManager.default.contentsOfDirectory(atPath: caches.path)) != nil
+    }
+
+    private func performScan() async {
+        isScanning = true
+        // A fresh scan means "back to browsing", not "just finished" — the
+        // freed-space banner is a one-time confirmation, not a sticky state.
+        lastFreed = nil
+        let built = Self.allTargets
+        var next: [CleanupItemState] = []
+        for target in built {
+            let available = await Task.detached(priority: .utility) { target.isAvailable() }.value
+            guard available else { continue }
+            let size = await Task.detached(priority: .utility) { Self.computeSize(for: target) }.value
+            next.append(CleanupItemState(
+                target: target,
+                isEnabled: isEnabled(target),
+                size: size,
+                blockedReason: target.isBlocked()
+            ))
+        }
+        items = next
+        fullDiskAccessOK = await Task.detached(priority: .utility) { Self.probeFullDiskAccess() }.value
+        isScanning = false
+    }
+
+    func cleanNow() async {
+        guard !isCleaning, !isScanning else { return }
+        isCleaning = true
+        let targets = items.filter { $0.isEnabled && $0.blockedReason == nil }.map(\.target)
+        let before = Self.availableCapacity()
+        await Task.detached(priority: .utility) {
+            for target in targets { Self.perform(target) }
+        }.value
+        let after = Self.availableCapacity()
+        isCleaning = false
+        // Rescan first so the list reflects what is actually left on disk,
+        // then stamp the freed total — otherwise the rescan above would wipe
+        // the very number this method just measured.
+        await performScan()
+        lastFreed = max(0, after - before)
+    }
+
+    // MARK: - Sizing
+
+    private nonisolated static func computeSize(for target: CleanupTarget) -> Int64? {
+        switch target.kind {
+        case .wholeFolderContents:
+            guard let root = target.resolve().first else { return nil }
+            return FileManager.default.allocatedSize(of: root)
+        case .exactDirectories:
+            return target.resolve().reduce(Int64(0)) { $0 + FileManager.default.allocatedSize(of: $1) }
+        case .exactFile, .sqliteVacuum:
+            guard let file = target.resolve().first else { return nil }
+            let values = try? file.resourceValues(forKeys: [.fileAllocatedSizeKey])
+            return Int64(values?.fileAllocatedSize ?? 0)
+        case .shellCommand:
+            return nil
+        }
+    }
+
+    private nonisolated static func availableCapacity() -> Int64 {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let values = try? home.resourceValues(forKeys: [.volumeAvailableCapacityKey])
+        return Int64(values?.volumeAvailableCapacity ?? 0)
+    }
+
+    // MARK: - Cleaning
+
+    /// Runs off the main actor — file trees and processes take as long as
+    /// they take, and this is the thread the whole panel lives on.
+    private nonisolated static func perform(_ target: CleanupTarget) {
+        let fm = FileManager.default
+        switch target.kind {
+        case .wholeFolderContents:
+            guard let root = target.resolve().first,
+                  let children = try? fm.contentsOfDirectory(at: root, includingPropertiesForKeys: nil)
+            else { return }
+            for child in children { try? fm.removeItem(at: child) }
+        case .exactFile:
+            guard let file = target.resolve().first else { return }
+            try? fm.removeItem(at: file)
+        case .exactDirectories:
+            for dir in target.resolve() { try? fm.removeItem(at: dir) }
+        case .shellCommand(let executable, let arguments):
+            guard !executable.isEmpty else { return }
+            run(executable, arguments)
+        case .sqliteVacuum:
+            guard let file = target.resolve().first, let sqlite3 = which("sqlite3") else { return }
+            run(sqlite3, [file.path, "VACUUM;"])
+        }
+    }
+
+    @discardableResult
+    private nonisolated static func run(_ executable: String, _ arguments: [String]) -> Bool {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: executable)
+        task.arguments = arguments
+        task.standardOutput = FileHandle.nullDevice
+        task.standardError = FileHandle.nullDevice
+        guard (try? task.run()) != nil else { return false }
+        task.waitUntilExit()
+        return task.terminationStatus == 0
+    }
+
+    /// `which <name>` via Process/Pipe.
+    private nonisolated static func which(_ name: String) -> String? {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        task.arguments = [name]
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = FileHandle.nullDevice
+        guard (try? task.run()) != nil else { return nil }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+        guard task.terminationStatus == 0,
+              let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !path.isEmpty
+        else { return nil }
+        return path
+    }
+
+    // MARK: - Targets
+
+    private nonisolated static var home: URL { FileManager.default.homeDirectoryForCurrentUser }
+
+    /// Exact, case-sensitive names this app will ever delete under
+    /// `~/Library/Application Support` — leaves of the recursive scan below.
+    /// Never a substring match: "Local Storage", "IndexedDB", and anything
+    /// else merely cache-adjacent stays untouched.
+    private nonisolated static let cacheDirAllowlist: Set<String> = [
+        "Cache", "Cache_Data", "CachedData", "Code Cache", "GPUCache",
+        "DawnWebGPUCache", "DawnGraphiteCache", "Crashpad", "CachedExtensionVSIXs",
+        "crx_cache", "appcache", "BrowserCaches", "PersistentCache",
+        "component_crx_cache", "CacheStorage", ".cache",
+    ]
+
+    /// Subtrees the recursive scan never even walks into, let alone deletes
+    /// from — the spec's "explicitly do not touch" list. `vm_bundles` is the
+    /// hard requirement (a VM disk image, not a cache; a nested `.cache` or
+    /// `Cache` directory inside a guest filesystem would otherwise match the
+    /// allowlist by name and get wiped). The three Cursor paths mirror the
+    /// spec's own carve-out for real extension/editor state living next to
+    /// the database this feature otherwise touches.
+    private nonisolated static var excludedRoots: [URL] {
+        [
+            home.appendingPathComponent("Library/Application Support/Claude/vm_bundles", isDirectory: true),
+            cursorSupportDir.appendingPathComponent("User/workspaceStorage", isDirectory: true),
+            cursorSupportDir.appendingPathComponent("User/History", isDirectory: true),
+            cursorSupportDir.appendingPathComponent("User/globalStorage", isDirectory: true),
+        ]
+    }
+
+    private nonisolated static func findAllowlistedCacheDirs() -> [URL] {
+        let root = home.appendingPathComponent("Library/Application Support", isDirectory: true)
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: []
+        ) else { return [] }
+        let excluded = excludedRoots
+        var matches: [URL] = []
+        for case let url as URL in enumerator {
+            guard (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else { continue }
+            if excluded.contains(where: { url.path == $0.path || url.path.hasPrefix($0.path + "/") }) {
+                enumerator.skipDescendants()
+                continue
+            }
+            guard cacheDirAllowlist.contains(url.lastPathComponent) else { continue }
+            matches.append(url)
+            // A match is a leaf: stop here rather than also collecting
+            // whatever cache subfolders happen to live inside it.
+            enumerator.skipDescendants()
+        }
+        return matches
+    }
+
+    private nonisolated static var cursorSupportDir: URL {
+        home.appendingPathComponent("Library/Application Support/Cursor", isDirectory: true)
+    }
+
+    private nonisolated static var cursorRunning: Bool {
+        NSWorkspace.shared.runningApplications.contains {
+            $0.bundleIdentifier == "com.todesktop.230313mzl4w4u92"
+        }
+    }
+
+    private nonisolated static var allTargets: [CleanupTarget] {
+        let dockerSocket = home.appendingPathComponent(".docker/run/docker.sock")
+        let dockerPath = which("docker")
+        let npmDir = home.appendingPathComponent(".npm", isDirectory: true)
+        let cacheDir = home.appendingPathComponent(".cache", isDirectory: true)
+        let cursorBackup = cursorSupportDir.appendingPathComponent("User/globalStorage/state.vscdb.backup")
+        let cursorDB = cursorSupportDir.appendingPathComponent("User/globalStorage/state.vscdb")
+
+        return [
+            CleanupTarget(
+                id: "caches",
+                title: localized("App & System Caches"),
+                description: localized("Everything in ~/Library/Caches — every app rebuilds this from scratch."),
+                kind: .wholeFolderContents,
+                defaultOn: true,
+                isAvailable: { true },
+                isBlocked: { nil },
+                resolve: { [home.appendingPathComponent("Library/Caches", isDirectory: true)] }
+            ),
+            CleanupTarget(
+                id: "npm",
+                title: localized("npm Package Cache"),
+                description: localized("~/.npm — npm re-downloads packages as needed."),
+                kind: .wholeFolderContents,
+                defaultOn: true,
+                isAvailable: { FileManager.default.fileExists(atPath: npmDir.path) },
+                isBlocked: { nil },
+                resolve: { [npmDir] }
+            ),
+            CleanupTarget(
+                id: "dotCache",
+                title: localized("CLI Tool Cache"),
+                description: localized("~/.cache — shared cache folder used by many command-line dev tools."),
+                kind: .wholeFolderContents,
+                defaultOn: true,
+                isAvailable: { FileManager.default.fileExists(atPath: cacheDir.path) },
+                isBlocked: { nil },
+                resolve: { [cacheDir] }
+            ),
+            CleanupTarget(
+                id: "pnpmStore",
+                title: localized("pnpm Store"),
+                description: localized("Runs “pnpm store prune” to drop packages nothing references anymore."),
+                kind: .shellCommand(executable: which("pnpm") ?? "", arguments: ["store", "prune"]),
+                defaultOn: true,
+                isAvailable: { which("pnpm") != nil },
+                isBlocked: { nil },
+                resolve: { [] }
+            ),
+            CleanupTarget(
+                id: "dockerPrune",
+                title: localized("Docker Unused Data"),
+                description: localized("Removes ALL unused images, containers, and volumes not currently in use — off by default, more destructive than the rest."),
+                kind: .shellCommand(executable: dockerPath ?? "", arguments: ["system", "prune", "-a", "--volumes", "-f"]),
+                defaultOn: false,
+                isAvailable: {
+                    guard FileManager.default.fileExists(atPath: dockerSocket.path), let dockerPath else { return false }
+                    return run(dockerPath, ["system", "df"])
+                },
+                isBlocked: { nil },
+                resolve: { [] }
+            ),
+            CleanupTarget(
+                id: "appSupportCaches",
+                title: localized("App Cache Subfolders"),
+                description: localized("Cache-style folders (Cache, GPUCache, Code Cache…) found anywhere under Application Support. Never touches saved app data."),
+                kind: .exactDirectories,
+                defaultOn: true,
+                isAvailable: { true },
+                isBlocked: { nil },
+                resolve: { findAllowlistedCacheDirs() }
+            ),
+            CleanupTarget(
+                id: "cursorBackup",
+                title: localized("Cursor Database Backup"),
+                description: localized("state.vscdb.backup — a leftover backup file, always safe to remove."),
+                kind: .exactFile,
+                defaultOn: true,
+                isAvailable: { FileManager.default.fileExists(atPath: cursorBackup.path) },
+                isBlocked: { nil },
+                resolve: { [cursorBackup] }
+            ),
+            CleanupTarget(
+                id: "cursorVacuum",
+                title: localized("Compact Cursor Database"),
+                description: localized("VACUUMs state.vscdb, reclaiming space from a known chat-history bloat bug. No data is lost."),
+                kind: .sqliteVacuum,
+                defaultOn: true,
+                isAvailable: { FileManager.default.fileExists(atPath: cursorDB.path) },
+                isBlocked: { cursorRunning ? localized("Quit Cursor first to compact its database") : nil },
+                resolve: { [cursorDB] }
+            ),
+        ]
+    }
+}
+
+private extension FileManager {
+    /// Recursive allocated size of everything under `url`. Used instead of
+    /// shelling out to `du -sh`, which this only falls back to if a target
+    /// ever needs sizing this can't reach.
+    func allocatedSize(of url: URL) -> Int64 {
+        guard let enumerator = enumerator(
+            at: url,
+            includingPropertiesForKeys: [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey, .isDirectoryKey],
+            options: []
+        ) else { return 0 }
+        var total: Int64 = 0
+        for case let fileURL as URL in enumerator {
+            guard let values = try? fileURL.resourceValues(forKeys: [.totalFileAllocatedSizeKey, .fileAllocatedSizeKey, .isDirectoryKey]),
+                  values.isDirectory != true
+            else { continue }
+            total += Int64(values.totalFileAllocatedSize ?? values.fileAllocatedSize ?? 0)
+        }
+        return total
+    }
+}

--- a/Sources/Cyclop/Services/CodexUsageStore.swift
+++ b/Sources/Cyclop/Services/CodexUsageStore.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Codex has no standalone "check my quota" endpoint the way Claude does —
+/// the rate-limit snapshot only ever comes back as a side effect of an actual
+/// turn, embedded in the CLI's own local session log. So this is read
+/// straight from that log instead: the same number the Codex TUI itself
+/// would be showing, as of the last time Codex was actually used.
+struct CodexUsageWindow: Decodable {
+    let usedPercent: Double?
+    let windowMinutes: Int?
+    let resetsAt: Int?
+
+    var resetDate: Date? { resetsAt.map { Date(timeIntervalSince1970: TimeInterval($0)) } }
+}
+
+struct CodexCredits: Decodable {
+    let hasCredits: Bool
+    let balance: String?
+}
+
+struct CodexRateLimits: Decodable {
+    let primary: CodexUsageWindow?
+    let secondary: CodexUsageWindow?
+    let credits: CodexCredits?
+}
+
+private struct CodexEventLine: Decodable {
+    let timestamp: String?
+    let payload: Payload
+    struct Payload: Decodable {
+        let rateLimits: CodexRateLimits?
+    }
+}
+
+/// Reads the newest `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` file for
+/// its last `rate_limits` snapshot — no token, no network, just the log the
+/// Codex CLI already writes after every turn.
+@MainActor
+final class CodexUsageStore: ObservableObject {
+    @Published private(set) var snapshot: CodexRateLimits?
+    /// When the snapshot's own event happened — the only honest freshness
+    /// this can offer, since it is only ever as current as Codex's last turn.
+    @Published private(set) var asOf: Date?
+
+    private static let root = FileManager.default.homeDirectoryForCurrentUser
+        .appending(path: ".codex/sessions")
+
+    func reload() {
+        guard let file = Self.latestRolloutFile(),
+              let data = try? Data(contentsOf: file),
+              let text = String(data: data, encoding: .utf8) else {
+            snapshot = nil
+            asOf = nil
+            return
+        }
+        // ponytail: only the newest session file is checked — good enough
+        // for a session used today; widen to the file before it if empty
+        // "no data" reports turn out to be common on lighter days.
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true).reversed() {
+            guard line.contains("\"rate_limits\":{") else { continue }
+            guard let event = try? decoder.decode(CodexEventLine.self, from: Data(line.utf8)),
+                  let rateLimits = event.payload.rateLimits else { continue }
+            snapshot = rateLimits
+            asOf = event.timestamp.flatMap(Self.parseTimestamp)
+            return
+        }
+        snapshot = nil
+        asOf = nil
+    }
+
+    private static func parseTimestamp(_ string: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: string)
+    }
+
+    /// Session logs live under `sessions/<year>/<month>/<day>/`, named so
+    /// that the lexically greatest entry at each level is also the newest.
+    private static func latestRolloutFile() -> URL? {
+        guard let year = latestChild(of: root) else { return nil }
+        guard let month = latestChild(of: year) else { return nil }
+        guard let day = latestChild(of: month) else { return nil }
+        return latestChild(of: day, extension: "jsonl")
+    }
+
+    private static func latestChild(of directory: URL, extension ext: String? = nil) -> URL? {
+        guard let items = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+        else { return nil }
+        let filtered = ext.map { e in items.filter { $0.pathExtension == e } } ?? items
+        return filtered.max { $0.lastPathComponent < $1.lastPathComponent }
+    }
+}

--- a/Sources/Cyclop/Services/CursorUsageStore.swift
+++ b/Sources/Cyclop/Services/CursorUsageStore.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Security
 
 /// Cursor's dashboard splits the billing cycle into two pools — "Cursor
 /// Models" (its own, cheaper models) and "Other Models" (everything else,
@@ -44,8 +43,8 @@ final class CursorUsageStore: ObservableObject {
     private var lastFetch: Date?
     private static let minRefetchInterval: TimeInterval = 20
 
-    func reload() {
-        if let lastFetch, Date().timeIntervalSince(lastFetch) < Self.minRefetchInterval { return }
+    func reload(force: Bool = false) {
+        if !force, let lastFetch, Date().timeIntervalSince(lastFetch) < Self.minRefetchInterval { return }
         lastFetch = Date()
         Task { await fetch() }
     }
@@ -56,28 +55,43 @@ final class CursorUsageStore: ObservableObject {
             unreachable = false
             return
         }
-        guard let fresh = await Self.fetchLive(token: token) else {
-            unreachable = true
+        if let fresh = await Self.fetchLive(token: token) {
+            snapshot = fresh
             noCredentials = false
+            unreachable = false
             return
         }
-        snapshot = fresh
+        UsageTokenCache.clearCursor()
+        if let retry = Self.token(), retry != token,
+           let fresh = await Self.fetchLive(token: retry) {
+            snapshot = fresh
+            noCredentials = false
+            unreachable = false
+            return
+        }
+        unreachable = true
         noCredentials = false
-        unreachable = false
     }
 
     private static func token() -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: "cursor-access-token",
-            kSecAttrAccount as String: "cursor-user",
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        var item: CFTypeRef?
-        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
-              let data = item as? Data else { return nil }
-        return String(data: data, encoding: .utf8)
+        if let data = UsageTokenCache.keychain(
+            service: "cursor-access-token",
+            account: "cursor-user",
+            allowPrompt: false
+        ), let token = String(data: data, encoding: .utf8), !token.isEmpty {
+            UsageTokenCache.storeCursor(token)
+            return token
+        }
+        if let cached = UsageTokenCache.cursor { return cached }
+        if let data = UsageTokenCache.keychain(
+            service: "cursor-access-token",
+            account: "cursor-user",
+            allowPrompt: true
+        ), let token = String(data: data, encoding: .utf8), !token.isEmpty {
+            UsageTokenCache.storeCursor(token)
+            return token
+        }
+        return nil
     }
 
     private static func fetchLive(token: String) async -> CursorUsageResponse? {

--- a/Sources/Cyclop/Services/CursorUsageStore.swift
+++ b/Sources/Cyclop/Services/CursorUsageStore.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Security
+
+/// Cursor's dashboard splits the billing cycle into two pools — "Cursor
+/// Models" (its own, cheaper models) and "Other Models" (everything else,
+/// which spills into on-demand spend once exhausted) — and the response
+/// carries a ready-made percentage for each, but only inside a sentence meant
+/// for display (`"You've used 1% of your included total usage"`). The
+/// numeric `auto_percent_used` / `api_percent_used` fields sit next to it and
+/// look like the same thing, but disagreed with what the dashboard actually
+/// showed when compared side by side — so the message text, not the numeric
+/// fields, is the one trusted here.
+struct CursorUsageResponse: Decodable {
+    let billingCycleEnd: String?
+    let autoModelSelectedDisplayMessage: String?
+    let namedModelSelectedDisplayMessage: String?
+
+    var resetDate: Date? {
+        guard let billingCycleEnd, let ms = Double(billingCycleEnd) else { return nil }
+        return Date(timeIntervalSince1970: ms / 1000)
+    }
+
+    var cursorModelsPercent: Double? { Self.percent(in: autoModelSelectedDisplayMessage) }
+    var otherModelsPercent: Double? { Self.percent(in: namedModelSelectedDisplayMessage) }
+
+    private static func percent(in message: String?) -> Double? {
+        guard let message, let range = message.range(of: #"\d+(\.\d+)?%"#, options: .regularExpression) else {
+            return nil
+        }
+        return Double(message[range].dropLast())
+    }
+}
+
+/// Same shape as `ClaudeUsageStore`: the Cursor CLI's own Connect-RPC call
+/// (`aiserver.v1.DashboardService/GetCurrentPeriodUsage`), authorized with
+/// the access token Cursor already stored in Keychain at login. No account
+/// of Cyclop's own, and a live number rather than a local guess.
+@MainActor
+final class CursorUsageStore: ObservableObject {
+    @Published private(set) var snapshot: CursorUsageResponse?
+    @Published private(set) var noCredentials = false
+    @Published private(set) var unreachable = false
+
+    private var lastFetch: Date?
+    private static let minRefetchInterval: TimeInterval = 20
+
+    func reload() {
+        if let lastFetch, Date().timeIntervalSince(lastFetch) < Self.minRefetchInterval { return }
+        lastFetch = Date()
+        Task { await fetch() }
+    }
+
+    private func fetch() async {
+        guard let token = Self.token() else {
+            noCredentials = true
+            unreachable = false
+            return
+        }
+        guard let fresh = await Self.fetchLive(token: token) else {
+            unreachable = true
+            noCredentials = false
+            return
+        }
+        snapshot = fresh
+        noCredentials = false
+        unreachable = false
+    }
+
+    private static func token() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "cursor-access-token",
+            kSecAttrAccount as String: "cursor-user",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func fetchLive(token: String) async -> CursorUsageResponse? {
+        var request = URLRequest(url: URL(string: "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage")!)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 5
+        request.httpBody = Data("{}".utf8)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("1", forHTTPHeaderField: "Connect-Protocol-Version")
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            return nil
+        }
+        return try? JSONDecoder().decode(CursorUsageResponse.self, from: data)
+    }
+}

--- a/Sources/Cyclop/Services/MemoryPressureStore.swift
+++ b/Sources/Cyclop/Services/MemoryPressureStore.swift
@@ -1,0 +1,247 @@
+import Darwin
+import Foundation
+
+/// RAM used, swap, disk, and the jetsam pressure Activity Monitor graphs.
+///
+/// The collapsed notch glows from **used percent** against the user's
+/// yellow/red thresholds — 70 / 90 out of the box — not from jetsam. Jetsam
+/// can go yellow while percent is still low, and the other way around on an
+/// 8 GB machine that is simply full. Percent is the number people mean.
+@MainActor
+final class MemoryPressureStore: ObservableObject {
+    enum Level: String {
+        case normal, warn, critical
+    }
+
+    @Published private(set) var level: Level = .normal
+    @Published private(set) var usedPercent: Double = 0
+    @Published private(set) var swapUsed: UInt64 = 0
+    @Published private(set) var swapTotal: UInt64 = 0
+    @Published private(set) var diskFree: Int64 = 0
+    @Published private(set) var yellowThreshold: Int
+    @Published private(set) var redThreshold: Int
+    /// Off: the notch only lights on red (jetsam 3+).
+    /// On: it also turns yellow/red when used RAM crosses the steppers.
+    @Published private(set) var glowFromPercent: Bool
+
+    let physicalMemory = ProcessInfo.processInfo.physicalMemory
+
+    static let diskWarnBytes: Int64 = 20 * 1024 * 1024 * 1024
+    static let defaultYellow = 90
+    static let defaultRed = 95
+
+    var diskIsLow: Bool { diskFree > 0 && diskFree < Self.diskWarnBytes }
+
+    /// Notch colour. Yellow on the Activity Monitor graph is a workday
+    /// baseline here, so the island stays dark until jetsam goes red.
+    /// Percent is an extra tripwire, and only when the user turned it on.
+    var glowLevel: Level {
+        let fromPressure: Level = level == .critical ? .critical : .normal
+        guard glowFromPercent else { return fromPressure }
+        let fromPercent: Level
+        if usedPercent >= Double(redThreshold) {
+            fromPercent = .critical
+        } else if usedPercent >= Double(yellowThreshold) {
+            fromPercent = .warn
+        } else {
+            fromPercent = .normal
+        }
+        switch (fromPressure, fromPercent) {
+        case (.critical, _), (_, .critical): return .critical
+        case (.warn, _), (_, .warn): return .warn
+        default: return .normal
+        }
+    }
+
+    private var source: DispatchSourceMemoryPressure?
+    private var timer: Timer?
+    private var tabIsActive = false
+
+    private static let yellowKey = "memory.glow.yellowPercent"
+    private static let redKey = "memory.glow.redPercent"
+    private static let percentKey = "memory.glow.fromPercent"
+
+    init() {
+        let defaults = UserDefaults.standard
+        let storedYellow = defaults.object(forKey: Self.yellowKey) as? Int
+        let storedRed = defaults.object(forKey: Self.redKey) as? Int
+        // 70/90 was the first shipped pair; treat it as "never customised".
+        let yellowRaw: Int
+        let redRaw: Int
+        if storedYellow == nil && storedRed == nil || storedYellow == 70 && storedRed == 90 {
+            yellowRaw = Self.defaultYellow
+            redRaw = Self.defaultRed
+        } else {
+            yellowRaw = storedYellow ?? Self.defaultYellow
+            redRaw = storedRed ?? Self.defaultRed
+        }
+        let yellow = Self.clampYellow(yellowRaw, red: redRaw)
+        yellowThreshold = yellow
+        redThreshold = Self.clampRed(redRaw, yellow: yellow)
+        glowFromPercent = defaults.bool(forKey: Self.percentKey)
+        if storedYellow != yellowThreshold || storedRed != redThreshold {
+            persistThresholds()
+        }
+    }
+
+    func start() {
+        refreshAll()
+        let source = DispatchSource.makeMemoryPressureSource(
+            eventMask: [.normal, .warning, .critical],
+            queue: .main
+        )
+        source.setEventHandler { [weak self] in
+            MainActor.assumeIsolated {
+                // Colour comes from sysctl, not from the dispatch flags —
+                // `.critical` fires already at "urgent", while Activity
+                // Monitor's graph is still yellow.
+                self?.refreshAll()
+            }
+        }
+        source.resume()
+        self.source = source
+        restartTimer()
+    }
+
+    func stop() {
+        source?.cancel()
+        source = nil
+        timer?.invalidate()
+        timer = nil
+    }
+
+    /// Faster poll while the Memory tab is on screen; a slow one otherwise,
+    /// so the collapsed rim can still flip when RAM crosses a threshold.
+    func setActive(_ active: Bool) {
+        tabIsActive = active
+        refreshAll()
+        restartTimer()
+    }
+
+    func adjustYellow(by delta: Int) {
+        setYellow(yellowThreshold + delta)
+    }
+
+    func adjustRed(by delta: Int) {
+        setRed(redThreshold + delta)
+    }
+
+    func setGlowFromPercent(_ on: Bool) {
+        glowFromPercent = on
+        UserDefaults.standard.set(on, forKey: Self.percentKey)
+    }
+
+    private func setYellow(_ value: Int) {
+        yellowThreshold = Self.clampYellow(value, red: redThreshold)
+        if redThreshold <= yellowThreshold {
+            redThreshold = Self.clampRed(yellowThreshold + 5, yellow: yellowThreshold)
+        }
+        persistThresholds()
+    }
+
+    private func setRed(_ value: Int) {
+        redThreshold = Self.clampRed(value, yellow: yellowThreshold)
+        if yellowThreshold >= redThreshold {
+            yellowThreshold = Self.clampYellow(redThreshold - 5, red: redThreshold)
+        }
+        persistThresholds()
+    }
+
+    private func persistThresholds() {
+        let defaults = UserDefaults.standard
+        defaults.set(yellowThreshold, forKey: Self.yellowKey)
+        defaults.set(redThreshold, forKey: Self.redKey)
+    }
+
+    private func restartTimer() {
+        timer?.invalidate()
+        let interval: TimeInterval = tabIsActive ? 5 : 15
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refreshAll() }
+        }
+        timer.tolerance = tabIsActive ? 1 : 5
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    private func refreshAll() {
+        refreshLevel()
+        refreshStats()
+    }
+
+    private func refreshLevel() {
+        var value: Int32 = 0
+        var size = MemoryLayout<Int32>.size
+        let ok = sysctlbyname("kern.memorystatus_vm_pressure_level", &value, &size, nil, 0) == 0
+        guard ok else { return }
+        // Activity Monitor: 0 green, 1–2 yellow, 3+ red. The notch ignores
+        // yellow and only glows at critical — see `glowLevel`.
+        switch value {
+        case 0: level = .normal
+        case 1, 2: level = .warn
+        default: level = .critical
+        }
+    }
+
+    private func refreshStats() {
+        usedPercent = Self.ramUsedPercent(physical: physicalMemory)
+        swapUsed = Self.swap().used
+        swapTotal = Self.swap().total
+        diskFree = Self.volumeFree()
+    }
+
+    private struct Swap {
+        var total: UInt64
+        var used: UInt64
+    }
+
+    /// Active + wired + compressed, over physical RAM. Cached files stay out
+    /// so a machine that is "full" of browser cache does not sit at 95% red.
+    private nonisolated static func ramUsedPercent(physical: UInt64) -> Double {
+        guard physical > 0 else { return 0 }
+        var stats = vm_statistics64()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<vm_statistics64_data_t>.size / MemoryLayout<integer_t>.size
+        )
+        let status = withUnsafeMutablePointer(to: &stats) { pointer -> kern_return_t in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
+            }
+        }
+        guard status == KERN_SUCCESS else { return 0 }
+        var pageSize: vm_size_t = 0
+        host_page_size(mach_host_self(), &pageSize)
+        let pages = UInt64(stats.active_count)
+            + UInt64(stats.wire_count)
+            + UInt64(stats.compressor_page_count)
+        let used = pages * UInt64(pageSize)
+        return min(100, Double(used) / Double(physical) * 100)
+    }
+
+    private nonisolated static func swap() -> Swap {
+        var usage = xsw_usage()
+        var size = MemoryLayout<xsw_usage>.size
+        guard sysctlbyname("vm.swapusage", &usage, &size, nil, 0) == 0 else {
+            return Swap(total: 0, used: 0)
+        }
+        return Swap(total: usage.xsu_total, used: usage.xsu_used)
+    }
+
+    private nonisolated static func volumeFree() -> Int64 {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let values = try? home.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        if let capacity = values?.volumeAvailableCapacityForImportantUsage {
+            return capacity
+        }
+        let fallback = try? home.resourceValues(forKeys: [.volumeAvailableCapacityKey])
+        return Int64(fallback?.volumeAvailableCapacity ?? 0)
+    }
+
+    private static func clampYellow(_ value: Int, red: Int) -> Int {
+        min(max(value, 40), min(red - 1, 95))
+    }
+
+    private static func clampRed(_ value: Int, yellow: Int) -> Int {
+        max(min(value, 99), max(yellow + 1, 50))
+    }
+}

--- a/Sources/Cyclop/Services/PomodoroStore.swift
+++ b/Sources/Cyclop/Services/PomodoroStore.swift
@@ -1,0 +1,255 @@
+import AppKit
+import UserNotifications
+
+/// Focus / break timer that lives in the notch: start it, close the panel,
+/// come back when the chime says the phase is over.
+@MainActor
+final class PomodoroStore: ObservableObject {
+    enum Phase: String {
+        case work, shortBreak, longBreak
+    }
+
+    enum Preset: String, CaseIterable, Identifiable {
+        case classic, short, long, custom
+        var id: String { rawValue }
+
+        /// `nil` for custom — the three minute fields are whatever the user left.
+        var durations: (work: Int, shortBreak: Int, longBreak: Int)? {
+            switch self {
+            case .classic: return (25, 5, 15)
+            case .short: return (15, 3, 10)
+            case .long: return (50, 10, 20)
+            case .custom: return nil
+            }
+        }
+    }
+
+    static let roundsUntilLongBreak = 4
+
+    @Published private(set) var preset: Preset
+    @Published private(set) var workMinutes: Int
+    @Published private(set) var shortBreakMinutes: Int
+    @Published private(set) var longBreakMinutes: Int
+
+    @Published private(set) var phase: Phase = .work
+    @Published private(set) var remaining: TimeInterval
+    @Published private(set) var isRunning = false
+    /// Work sessions finished this run of the app — drives the long-break cadence.
+    @Published private(set) var completedRounds = 0
+
+    private static let presetKey = "pomodoro.preset"
+    private static let workKey = "pomodoro.workMinutes"
+    private static let shortKey = "pomodoro.shortBreakMinutes"
+    private static let longKey = "pomodoro.longBreakMinutes"
+
+    private let defaults = UserDefaults.standard
+    private var endsAt: Date?
+    private var timer: Timer?
+    private var askedForNotifications = false
+
+    init() {
+        let work = Self.clampWork(defaults.object(forKey: Self.workKey) as? Int ?? 25)
+        let shortBreak = Self.clampBreak(defaults.object(forKey: Self.shortKey) as? Int ?? 5)
+        let longBreak = Self.clampBreak(defaults.object(forKey: Self.longKey) as? Int ?? 15)
+
+        var resolved = Preset.classic
+        if let raw = defaults.string(forKey: Self.presetKey),
+           let stored = Preset(rawValue: raw) {
+            resolved = stored
+        }
+        // A stored "classic" whose minutes were edited by hand is custom.
+        if let durations = resolved.durations,
+           (work, shortBreak, longBreak) != (durations.work, durations.shortBreak, durations.longBreak) {
+            resolved = .custom
+        }
+
+        preset = resolved
+        workMinutes = work
+        shortBreakMinutes = shortBreak
+        longBreakMinutes = longBreak
+        remaining = TimeInterval(work * 60)
+    }
+
+    var phaseTitle: String {
+        switch phase {
+        case .work: return localized("Focus")
+        case .shortBreak: return localized("Break")
+        case .longBreak: return localized("Long Break")
+        }
+    }
+
+    /// Phase whose colour should ring the collapsed island, if any.
+    /// `nil` when the timer is idle — the notch goes back to plain black.
+    var collapsedRimPhase: Phase? { isRunning ? phase : nil }
+
+    var clock: String {
+        let total = max(0, Int(remaining.rounded(.up)))
+        return String(format: "%d:%02d", total / 60, total % 60)
+    }
+
+    /// Dots under the clock: filled for finished rounds in the current set of four.
+    var roundIndexInSet: Int {
+        completedRounds % Self.roundsUntilLongBreak
+    }
+
+    func selectPreset(_ next: Preset) {
+        preset = next
+        defaults.set(next.rawValue, forKey: Self.presetKey)
+        guard let durations = next.durations else { return }
+        workMinutes = durations.work
+        shortBreakMinutes = durations.shortBreak
+        longBreakMinutes = durations.longBreak
+        persistDurations()
+        if !isRunning {
+            remaining = TimeInterval(durationMinutes(for: phase) * 60)
+        }
+    }
+
+    func adjustWork(by delta: Int) { adjust(\.workMinutes, by: delta, clamp: Self.clampWork) }
+    func adjustShortBreak(by delta: Int) { adjust(\.shortBreakMinutes, by: delta, clamp: Self.clampBreak) }
+    func adjustLongBreak(by delta: Int) { adjust(\.longBreakMinutes, by: delta, clamp: Self.clampBreak) }
+
+    func toggle() { isRunning ? pause() : start() }
+
+    func start() {
+        guard !isRunning else { return }
+        requestNotificationsIfNeeded()
+        if remaining <= 0 {
+            remaining = TimeInterval(durationMinutes(for: phase) * 60)
+        }
+        endsAt = Date().addingTimeInterval(remaining)
+        isRunning = true
+        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated { self?.tick() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    func pause() {
+        guard isRunning else { return }
+        syncRemainingFromClock()
+        endsAt = nil
+        isRunning = false
+        timer?.invalidate()
+        timer = nil
+    }
+
+    /// Jump to the next phase without counting the current one as finished.
+    func skip() {
+        let wasRunning = isRunning
+        pause()
+        switch phase {
+        case .work:
+            phase = .shortBreak
+        case .shortBreak, .longBreak:
+            phase = .work
+        }
+        remaining = TimeInterval(durationMinutes(for: phase) * 60)
+        if wasRunning { start() }
+    }
+
+    /// Back to a full Focus, stopped, rounds kept.
+    func reset() {
+        pause()
+        phase = .work
+        remaining = TimeInterval(workMinutes * 60)
+    }
+
+    // MARK: - Private
+
+    private func adjust(
+        _ keyPath: ReferenceWritableKeyPath<PomodoroStore, Int>,
+        by delta: Int,
+        clamp: (Int) -> Int
+    ) {
+        let next = clamp(self[keyPath: keyPath] + delta)
+        guard next != self[keyPath: keyPath] else { return }
+        self[keyPath: keyPath] = next
+        if preset != .custom {
+            preset = .custom
+            defaults.set(Preset.custom.rawValue, forKey: Self.presetKey)
+        }
+        persistDurations()
+        if !isRunning {
+            remaining = TimeInterval(durationMinutes(for: phase) * 60)
+        }
+    }
+
+    private func persistDurations() {
+        defaults.set(workMinutes, forKey: Self.workKey)
+        defaults.set(shortBreakMinutes, forKey: Self.shortKey)
+        defaults.set(longBreakMinutes, forKey: Self.longKey)
+    }
+
+    private func durationMinutes(for phase: Phase) -> Int {
+        switch phase {
+        case .work: return workMinutes
+        case .shortBreak: return shortBreakMinutes
+        case .longBreak: return longBreakMinutes
+        }
+    }
+
+    private func tick() {
+        guard isRunning, let endsAt else { return }
+        let left = endsAt.timeIntervalSinceNow
+        if left <= 0 {
+            remaining = 0
+            finishPhase()
+        } else {
+            remaining = left
+        }
+    }
+
+    private func syncRemainingFromClock() {
+        if let endsAt {
+            remaining = max(0, endsAt.timeIntervalSinceNow)
+        }
+    }
+
+    private func finishPhase() {
+        pause()
+        announce()
+        advance(completedWork: phase == .work)
+        start()
+    }
+
+    private func advance(completedWork: Bool) {
+        if completedWork {
+            completedRounds += 1
+            if completedRounds % Self.roundsUntilLongBreak == 0 {
+                phase = .longBreak
+            } else {
+                phase = .shortBreak
+            }
+        } else {
+            phase = .work
+        }
+        remaining = TimeInterval(durationMinutes(for: phase) * 60)
+    }
+
+    private func announce() {
+        NSSound(named: "Glass")?.play()
+        let content = UNMutableNotificationContent()
+        content.title = "Cyclop"
+        content.body = phase == .work
+            ? localized("Focus done — time for a break")
+            : localized("Break over — back to focus")
+        content.sound = nil
+        let request = UNNotificationRequest(
+            identifier: "pomodoro.\(UUID().uuidString)",
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+    }
+
+    private func requestNotificationsIfNeeded() {
+        guard !askedForNotifications else { return }
+        askedForNotifications = true
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+    }
+
+    private static func clampWork(_ value: Int) -> Int { min(max(value, 1), 90) }
+    private static func clampBreak(_ value: Int) -> Int { min(max(value, 1), 60) }
+}

--- a/Sources/Cyclop/Services/SleepManager.swift
+++ b/Sources/Cyclop/Services/SleepManager.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Keeps the Mac awake with the lid closed by wrapping `caffeinate -s` — the
+/// same one-job trick as the standalone LidAwake utility, folded in here
+/// instead of running as a second menu-bar app. There is never more than one
+/// child process in flight, and only the exact instance this manager
+/// launched is ever terminated.
+@MainActor
+final class SleepManager: ObservableObject {
+    @Published private(set) var isEnabled = false
+    @Published private(set) var errorMessage: String?
+
+    private static let persistedKey = "keepAwakeEnabled"
+    private var process: Process?
+
+    init() {
+        if UserDefaults.standard.bool(forKey: Self.persistedKey) {
+            enable()
+        }
+    }
+
+    func setEnabled(_ shouldBeEnabled: Bool) {
+        shouldBeEnabled ? enable() : disable()
+    }
+
+    /// Called on quit — an orphaned `caffeinate` would otherwise keep the Mac
+    /// awake forever with nothing left to turn it off from.
+    func stop() {
+        disable()
+    }
+
+    private func enable() {
+        if let process, process.isRunning {
+            isEnabled = true
+            return
+        }
+        errorMessage = nil
+
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/caffeinate")
+        task.arguments = ["-s"]
+        // Cleared before an intentional `terminate()` in `disable()`, so this
+        // only ever fires on an unexpected exit — no identity check needed.
+        task.terminationHandler = { [weak self] _ in
+            Task { @MainActor [weak self] in self?.handleUnexpectedTermination() }
+        }
+
+        do {
+            try task.run()
+            process = task
+            isEnabled = true
+            UserDefaults.standard.set(true, forKey: Self.persistedKey)
+        } catch {
+            NSLog("Cyclop: failed to launch caffeinate: \(error.localizedDescription)")
+            errorMessage = error.localizedDescription
+            isEnabled = false
+            UserDefaults.standard.set(false, forKey: Self.persistedKey)
+        }
+    }
+
+    private func disable() {
+        guard let task = process else {
+            isEnabled = false
+            return
+        }
+        task.terminationHandler = nil
+        if task.isRunning { task.terminate() }
+        process = nil
+        isEnabled = false
+        UserDefaults.standard.set(false, forKey: Self.persistedKey)
+    }
+
+    private func handleUnexpectedTermination() {
+        guard process != nil else { return }
+        process = nil
+        isEnabled = false
+        UserDefaults.standard.set(false, forKey: Self.persistedKey)
+        errorMessage = "caffeinate exited unexpectedly"
+        NSLog("Cyclop: caffeinate exited unexpectedly")
+    }
+
+    deinit {
+        process?.terminationHandler = nil
+        if process?.isRunning == true {
+            process?.terminate()
+        }
+    }
+}

--- a/Sources/Cyclop/Services/UsageTokenCache.swift
+++ b/Sources/Cyclop/Services/UsageTokenCache.swift
@@ -1,0 +1,67 @@
+import Foundation
+import LocalAuthentication
+import Security
+
+/// Keychain reads of Claude's and Cursor's items pop a password dialog for
+/// any app that is not already on the item's ACL — and an ad-hoc rebuild
+/// looks like a new app every time. The dialog is suppressed; a successful
+/// read is cached in Cyclop's own folder so the next visit never asks.
+enum UsageTokenCache {
+    private static let url = Support.file("usage-tokens.json")
+
+    static var claude: String? { read("claude") }
+    static var cursor: String? { read("cursor") }
+
+    static func storeClaude(_ token: String) { write("claude", token) }
+    static func storeCursor(_ token: String) { write("cursor", token) }
+    static func clearClaude() { write("claude", nil) }
+    static func clearCursor() { write("cursor", nil) }
+
+    /// `allowPrompt` is the last resort — once, then the bytes live in the
+    /// cache file and Keychain is not asked again.
+    static func keychain(service: String, account: String? = nil, allowPrompt: Bool) -> Data? {
+        let context = LAContext()
+        context.interactionNotAllowed = !allowPrompt
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecUseAuthenticationContext as String: context,
+        ]
+        if let account {
+            query[kSecAttrAccount as String] = account
+        }
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess else {
+            return nil
+        }
+        return item as? Data
+    }
+
+    private static func read(_ key: String) -> String? {
+        guard let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: String],
+              let token = json[key], !token.isEmpty
+        else { return nil }
+        return token
+    }
+
+    private static func write(_ key: String, _ token: String?) {
+        var json = (try? Data(contentsOf: url)).flatMap {
+            try? JSONSerialization.jsonObject(with: $0) as? [String: String]
+        } ?? [:]
+        if let token, !token.isEmpty {
+            json[key] = token
+        } else {
+            json.removeValue(forKey: key)
+        }
+        if json.isEmpty {
+            try? FileManager.default.removeItem(at: url)
+            return
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: json) else { return }
+        try? data.write(to: url, options: .atomic)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+}

--- a/Sources/Cyclop/UI/CleanupPane.swift
+++ b/Sources/Cyclop/UI/CleanupPane.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+/// Safe, regenerable caches: sized on the way in, deleted only where checked.
+///
+/// The Memory tab owns the scroll view — this is just the list and the
+/// button, so pressure and cleanup move together.
+struct CleanupList: View {
+    @ObservedObject var cleanup: CleanupStore
+
+    @State private var confirmArmed = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if !cleanup.fullDiskAccessOK {
+                fullDiskAccessNotice
+            }
+
+            VStack(spacing: 1) {
+                ForEach(cleanup.items) { item in
+                    row(item)
+                }
+            }
+            .padding(4)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(Theme.surface)
+            )
+
+            footer
+        }
+        .task(id: confirmArmed) {
+            guard confirmArmed else { return }
+            try? await Task.sleep(for: .seconds(4))
+            guard !Task.isCancelled else { return }
+            confirmArmed = false
+        }
+    }
+
+    private func row(_ item: CleanupItemState) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: symbol(for: item.target.id))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Theme.secondary)
+                .frame(width: 16)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(item.target.title)
+                    .font(.system(size: 11.5, weight: .medium))
+                    .foregroundStyle(.white)
+                Text(item.blockedReason ?? item.target.description)
+                    .font(.system(size: 9.5, weight: .medium))
+                    .foregroundStyle(item.blockedReason == nil ? Theme.tertiary : Color.orange.opacity(0.85))
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            Text(sizeLabel(item.size))
+                .font(.system(size: 10, weight: .medium).monospacedDigit())
+                .foregroundStyle(Theme.tertiary)
+            Toggle("", isOn: Binding(
+                get: { item.isEnabled },
+                set: { cleanup.setEnabled(item.target.id, $0) }
+            ))
+            .toggleStyle(.switch)
+            .controlSize(.mini)
+            .labelsHidden()
+            .disabled(item.blockedReason != nil)
+        }
+        .padding(.horizontal, 8)
+        .frame(height: 32)
+        .opacity(item.blockedReason == nil ? 1 : 0.6)
+    }
+
+    private func symbol(for id: String) -> String {
+        switch id {
+        case "caches": return "internaldrive"
+        case "npm": return "shippingbox"
+        case "dotCache": return "terminal"
+        case "pnpmStore": return "cube.box"
+        case "dockerPrune": return "cube.transparent"
+        case "appSupportCaches": return "square.stack.3d.up"
+        case "cursorBackup": return "doc.badge.clock"
+        case "cursorVacuum": return "arrow.triangle.2.circlepath"
+        default: return "trash"
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 8) {
+            if let freed = cleanup.lastFreed {
+                Text(localized("Freed %@", humanSize(freed)))
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.white)
+            } else if cleanup.isScanning {
+                Text(localized("Scanning…"))
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Theme.tertiary)
+            } else {
+                Text(localized("Reclaimable: %@", humanSize(cleanup.totalReclaimable)))
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Theme.secondary)
+            }
+            Spacer(minLength: 8)
+            cleanButton
+        }
+        .padding(.horizontal, 4)
+    }
+
+    private var nothingSelected: Bool {
+        cleanup.items.allSatisfy { !$0.isEnabled || $0.blockedReason != nil }
+    }
+
+    private var cleanButton: some View {
+        Button {
+            if confirmArmed {
+                confirmArmed = false
+                Task { await cleanup.cleanNow() }
+            } else {
+                confirmArmed = true
+            }
+        } label: {
+            HStack(spacing: 6) {
+                if cleanup.isCleaning {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: confirmArmed ? "checkmark.circle.fill" : "trash")
+                        .font(.system(size: 11, weight: .medium))
+                }
+                Text(confirmArmed ? localized("Tap to Confirm") : localized("Clean Now"))
+                    .font(.system(size: 11, weight: .semibold))
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 12)
+            .frame(height: 26)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(confirmArmed ? Color.red.opacity(0.55) : Theme.surfaceHover)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(cleanup.isCleaning || cleanup.isScanning || !cleanup.fullDiskAccessOK || nothingSelected)
+        .opacity((cleanup.isCleaning || cleanup.isScanning || !cleanup.fullDiskAccessOK || nothingSelected) ? 0.5 : 1)
+    }
+
+    private var fullDiskAccessNotice: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(localized("Cyclop needs Full Disk Access to clean system caches"))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.white)
+            Text(localized("Quit and reopen Cyclop after granting access."))
+                .font(.system(size: 9.5, weight: .medium))
+                .foregroundStyle(Theme.tertiary)
+            Button {
+                cleanup.openFullDiskAccessSettings()
+            } label: {
+                Text(localized("Open Full Disk Access Settings"))
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 10)
+                    .frame(height: 22)
+                    .background(Capsule(style: .continuous).fill(Theme.surfaceHover))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 10, style: .continuous).fill(Theme.surface))
+    }
+
+    private func humanSize(_ bytes: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+
+    private func sizeLabel(_ bytes: Int64?) -> String {
+        guard let bytes else { return "–" }
+        return humanSize(bytes)
+    }
+}

--- a/Sources/Cyclop/UI/CreditsPane.swift
+++ b/Sources/Cyclop/UI/CreditsPane.swift
@@ -1,22 +1,60 @@
 import SwiftUI
 
+private struct CardHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
 struct CreditsPane: View {
     @ObservedObject var usage: ClaudeUsageStore
     @ObservedObject var codex: CodexUsageStore
     @ObservedObject var cursor: CursorUsageStore
+    @ObservedObject var providers: UsageProviderSettings
 
-    // Three cards of uneven depth: Claude carries the plan windows plus
-    // extra usage, so it owns the left column; Codex and Cursor share the
-    // right, each stretched to half the pane so the tops and bottoms line up.
+    /// Claude's extra-usage line makes it taller than the others; every card
+    /// is pinned to that height so the row is even.
+    @State private var cardHeight: CGFloat?
+
+    private var enabledProviders: [UsageProvider] { providers.enabled }
+    private var columns: Int { UsageGrid.columns(for: enabledProviders.count) }
+
     var body: some View {
-        HStack(alignment: .top, spacing: 8) {
-            cell { claudeContent }
-            VStack(spacing: 8) {
-                cell { codexContent }
-                cell { cursorContent }
+        Group {
+            if enabledProviders.isEmpty {
+                caption(localized("No usage cards enabled — turn some on in Settings"))
+            } else {
+                LazyVGrid(
+                    columns: Array(repeating: GridItem(.flexible(), spacing: UsageGrid.rowSpacing), count: columns),
+                    alignment: .leading,
+                    spacing: UsageGrid.rowSpacing
+                ) {
+                    ForEach(enabledProviders) { provider in
+                        cell { content(for: provider) }
+                            .frame(height: cardHeight)
+                    }
+                }
+                .fixedSize(horizontal: false, vertical: true)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .onPreferenceChange(CardHeightKey.self) { if $0 > 0 { cardHeight = $0 } }
+        .onChange(of: enabledProviders.count) { _, _ in cardHeight = nil }
+        .onAppear {
+            usage.reload()
+            cursor.reload()
+            codex.reload()
+        }
+    }
+
+    @ViewBuilder
+    private func content(for provider: UsageProvider) -> some View {
+        switch provider {
+        case .claude: claudeContent
+        case .codex: codexContent
+        case .cursor: cursorContent
+        }
     }
 
     private func cell<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
@@ -25,7 +63,12 @@ struct CreditsPane: View {
             Spacer(minLength: 0)
         }
         .padding(10)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(
+            GeometryReader { proxy in
+                Color.clear.preference(key: CardHeightKey.self, value: proxy.size.height)
+            }
+        )
         .background(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .fill(Theme.surface)

--- a/Sources/Cyclop/UI/CreditsPane.swift
+++ b/Sources/Cyclop/UI/CreditsPane.swift
@@ -1,0 +1,214 @@
+import SwiftUI
+
+struct CreditsPane: View {
+    @ObservedObject var usage: ClaudeUsageStore
+    @ObservedObject var codex: CodexUsageStore
+    @ObservedObject var cursor: CursorUsageStore
+
+    // Three cards of uneven depth: Claude carries the plan windows plus
+    // extra usage, so it owns the left column; Codex and Cursor share the
+    // right, each stretched to half the pane so the tops and bottoms line up.
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            cell { claudeContent }
+            VStack(spacing: 8) {
+                cell { codexContent }
+                cell { cursorContent }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func cell<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            content()
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Theme.surface)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+    // MARK: - Claude
+
+    @ViewBuilder
+    private var claudeContent: some View {
+        brand("CLAUDE")
+        if let snapshot = usage.snapshot {
+            row(title: localized("5-hour window"), percent: snapshot.fiveHour.utilization, resetsAt: snapshot.fiveHour.resetsAt)
+            row(title: localized("7-day window"), percent: snapshot.sevenDay.utilization, resetsAt: snapshot.sevenDay.resetsAt)
+            if let extra = snapshot.extraUsage, extra.isEnabled {
+                extraRow(extra)
+            }
+        } else if usage.noCredentials {
+            caption(localized("Not signed in to Claude"))
+        } else {
+            caption(localized("Can't reach Claude"))
+        }
+    }
+
+    private func extraRow(_ extra: ClaudeExtraUsage) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 4) {
+                Text(localized("Extra usage"))
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Theme.secondary)
+                Spacer(minLength: 4)
+                if let used = extra.used, let limit = extra.limit {
+                    Text("\(currency(used, extra.currency)) / \(currency(limit, extra.currency))")
+                        .font(.system(size: 9).monospacedDigit())
+                        .foregroundStyle(Theme.tertiary)
+                }
+            }
+            bar(extra.utilization)
+        }
+    }
+
+    // MARK: - Codex
+
+    @ViewBuilder
+    private var codexContent: some View {
+        brand("CODEX")
+        if let rateLimits = codex.snapshot {
+            if let primary = rateLimits.primary {
+                row(title: windowLabel(minutes: primary.windowMinutes), percent: primary.usedPercent, resetsAt: primary.resetDate)
+            }
+            if let secondary = rateLimits.secondary {
+                row(title: windowLabel(minutes: secondary.windowMinutes), percent: secondary.usedPercent, resetsAt: secondary.resetDate)
+            }
+            if let credits = rateLimits.credits, credits.hasCredits, let balance = credits.balance {
+                HStack(spacing: 4) {
+                    Text(localized("Extra usage"))
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Theme.secondary)
+                    Spacer(minLength: 4)
+                    Text(balance)
+                        .font(.system(size: 9).monospacedDigit())
+                        .foregroundStyle(Theme.tertiary)
+                }
+            }
+            if let asOf = codex.asOf {
+                caption(Self.asOfLabel(for: asOf))
+            }
+        } else {
+            caption(localized("No Codex sessions found yet"))
+        }
+    }
+
+    private func windowLabel(minutes: Int?) -> String {
+        guard let minutes, minutes > 0 else { return localized("Usage") }
+        if minutes % 1440 == 0 { return localized("%d-day window", minutes / 1440) }
+        return localized("%d-hour window", max(minutes / 60, 1))
+    }
+
+    // MARK: - Cursor
+
+    @ViewBuilder
+    private var cursorContent: some View {
+        brand("CURSOR")
+        if let snapshot = cursor.snapshot {
+            row(title: localized("Cursor Models"), percent: snapshot.cursorModelsPercent, resetsAt: snapshot.resetDate)
+            row(title: localized("Other Models"), percent: snapshot.otherModelsPercent)
+        } else if cursor.noCredentials {
+            caption(localized("Not signed in to Cursor"))
+        } else {
+            caption(localized("Can't reach Cursor"))
+        }
+    }
+
+    // MARK: - Shared row
+
+    private func brand(_ name: String) -> some View {
+        Text(name)
+            .font(.system(size: 10, weight: .semibold))
+            .tracking(0.8)
+            .foregroundStyle(Theme.tertiary)
+    }
+
+    private func caption(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 9.5))
+            .foregroundStyle(Theme.tertiary)
+    }
+
+    private func row(title: String, percent value: Double?, resetsAt: Date? = nil) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 4) {
+                Text(title)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Theme.secondary)
+                Spacer(minLength: 4)
+                Text(percent(value))
+                    .font(.system(size: 11, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(color(for: value))
+            }
+            bar(value)
+            if let resetsAt {
+                Text(Self.resetLabel(for: resetsAt))
+                    .font(.system(size: 8.5))
+                    .foregroundStyle(Theme.tertiary)
+            }
+        }
+    }
+
+    private func bar(_ utilization: Double?) -> some View {
+        let fraction = min(max((utilization ?? 0) / 100, 0), 1)
+        return GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule().fill(Theme.hairline)
+                Capsule()
+                    .fill(color(for: utilization))
+                    .frame(width: max(proxy.size.width * fraction, fraction > 0 ? 4 : 0))
+            }
+        }
+        .frame(height: 4)
+    }
+
+    private func percent(_ utilization: Double?) -> String {
+        guard let utilization else { return "—" }
+        return "\(Int(utilization.rounded()))%"
+    }
+
+    private func currency(_ value: Double, _ code: String?) -> String {
+        String(format: "%.2f %@", value, code ?? "")
+    }
+
+    /// White past halfway, amber once it starts to matter, red once there is
+    /// barely anything left — the same three-stop read as a phone's battery
+    /// icon, chosen because nobody has to learn it.
+    private func color(for utilization: Double?) -> Color {
+        guard let utilization else { return Theme.tertiary }
+        if utilization >= 90 { return .red }
+        if utilization >= 70 { return .yellow }
+        return .white.opacity(0.85)
+    }
+
+    private static let elapsedFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.day, .hour, .minute]
+        formatter.maximumUnitCount = 1
+        formatter.unitsStyle = .abbreviated
+        formatter.calendar?.locale = Locale(identifier: appLanguage)
+        return formatter
+    }()
+
+    private static func resetLabel(for date: Date) -> String {
+        let interval = date.timeIntervalSinceNow
+        guard interval > 0, let span = elapsedFormatter.string(from: interval) else {
+            return localized("resets any moment")
+        }
+        return localized("resets in %@", span)
+    }
+
+    private static func asOfLabel(for date: Date) -> String {
+        let interval = -date.timeIntervalSinceNow
+        guard interval > 60, let span = elapsedFormatter.string(from: interval) else {
+            return localized("as of just now")
+        }
+        return localized("as of %@ ago", span)
+    }
+}

--- a/Sources/Cyclop/UI/MemoryPane.swift
+++ b/Sources/Cyclop/UI/MemoryPane.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+/// Activity Monitor's Memory Pressure, plus the caches that free SSD space
+/// when RAM has already spilled into swap.
+struct MemoryPane: View {
+    @ObservedObject var memory: MemoryPressureStore
+    @ObservedObject var cleanup: CleanupStore
+
+    var body: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 10) {
+                pressureCard
+                statsRow
+                CleanupList(cleanup: cleanup)
+            }
+            .padding(.top, 2)
+            .padding(.trailing, 4)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var pressureCard: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(Self.color(for: memory.level))
+                .frame(width: 10, height: 10)
+                .shadow(color: Self.color(for: memory.level).opacity(0.8), radius: 6)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(Int(memory.usedPercent.rounded()))%")
+                    .font(.system(size: 16, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(.white)
+                Text(Self.caption(for: memory))
+                    .font(.system(size: 9.5, weight: .medium))
+                    .foregroundStyle(Theme.tertiary)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 0)
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(Self.title(for: memory.level))
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(Theme.tertiary)
+                Text(localized("Jetsam"))
+                    .font(.system(size: 8.5, weight: .medium))
+                    .foregroundStyle(Theme.tertiary.opacity(0.7))
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Theme.surface)
+        )
+    }
+
+    private var statsRow: some View {
+        HStack(spacing: 8) {
+            stat(
+                title: localized("Swap"),
+                value: bytes(Int64(memory.swapUsed)),
+                warn: memory.swapUsed > 0 && memory.level != .normal
+            )
+            stat(
+                title: localized("Disk free"),
+                value: bytes(memory.diskFree),
+                warn: memory.diskIsLow
+            )
+        }
+    }
+
+    private func stat(title: String, value: String, warn: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(Theme.tertiary)
+            Text(value)
+                .font(.system(size: 12, weight: .semibold).monospacedDigit())
+                .foregroundStyle(warn ? Color(red: 1.0, green: 0.78, blue: 0.20) : .white)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Theme.surface)
+        )
+    }
+
+    private func bytes(_ value: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: value, countStyle: .file)
+    }
+
+    static func color(for level: MemoryPressureStore.Level) -> Color {
+        switch level {
+        case .normal: return Color(red: 0.35, green: 0.82, blue: 0.55)
+        case .warn: return Color(red: 1.0, green: 0.78, blue: 0.20)
+        case .critical: return Color(red: 1.0, green: 0.35, blue: 0.32)
+        }
+    }
+
+    private static func title(for level: MemoryPressureStore.Level) -> String {
+        switch level {
+        case .normal: return localized("Memory Pressure · Green")
+        case .warn: return localized("Memory Pressure · Yellow")
+        case .critical: return localized("Memory Pressure · Red")
+        }
+    }
+
+    private static func caption(for memory: MemoryPressureStore) -> String {
+        if memory.glowFromPercent {
+            return hint(for: memory.glowLevel)
+        }
+        switch memory.glowLevel {
+        case .critical:
+            return localized("The Mac is swapping. Close tabs, then clean caches below.")
+        case .warn:
+            return hint(for: .warn)
+        case .normal:
+            if memory.level == .warn {
+                return localized("Graph is yellow. Notch stays dark until red.")
+            }
+            return localized("Notch stays dark until red.")
+        }
+    }
+
+    private static func hint(for level: MemoryPressureStore.Level) -> String {
+        switch level {
+        case .normal: return localized("Running optimally.")
+        case .warn: return localized("Close unneeded tabs and quit unused apps.")
+        case .critical: return localized("The Mac is swapping. Close tabs, then clean caches below.")
+        }
+    }
+}

--- a/Sources/Cyclop/UI/NotchContentView.swift
+++ b/Sources/Cyclop/UI/NotchContentView.swift
@@ -15,7 +15,7 @@ struct NotchContentView: View {
             bottomRadius: isOpen ? Theme.openBottomRadius : Theme.collapsedBottomRadius
         )
         let shapeWidth = size.width + 2 * topRadius
-        let rim = isOpen ? nil : Self.rimColor(for: vm.pomodoro.collapsedRimPhase)
+        let rim = (isOpen && vm.rimPreview == .none) ? nil : Self.rimColor(for: vm.collapsedRim)
         // Collapsed, paint a hair past the reported notch: `auxiliaryTop*Area`
         // width is occasionally a point shy of the cutout the eye reads, and a
         // stroke on that tight box looked biased to one side.
@@ -66,17 +66,29 @@ struct NotchContentView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .animation(Theme.openAnimation, value: isOpen)
         .animation(Theme.paneAnimation, value: vm.tab)
-        .animation(.easeInOut(duration: 0.35), value: vm.pomodoro.collapsedRimPhase)
+        .animation(.easeInOut(duration: 0.35), value: vm.collapsedRim)
     }
 
-    /// Coral while focusing, mint on a short break, blue on a long one —
-    /// readable at a glance from across the desk.
-    private static func rimColor(for phase: PomodoroStore.Phase?) -> Color? {
-        switch phase {
-        case .work: return Color(red: 1.0, green: 0.38, blue: 0.32)
-        case .shortBreak: return Color(red: 0.35, green: 0.82, blue: 0.55)
-        case .longBreak: return Color(red: 0.40, green: 0.62, blue: 1.0)
-        case nil: return nil
+    /// Meeting neon, then memory yellow/red, then pomodoro. Green memory
+    /// is silence — the island stays black, same as Activity Monitor's
+    /// "everything is fine".
+    private static func rimColor(for rim: NotchViewModel.CollapsedRim) -> Color? {
+        switch rim {
+        case .none:
+            return nil
+        case .meeting(let pulsing):
+            let neon = Color(red: 0.45, green: 0.85, blue: 1.0)
+            return pulsing ? neon : neon.opacity(0.55)
+        case .memoryWarn:
+            return Color(red: 1.0, green: 0.78, blue: 0.20)
+        case .memoryCritical:
+            return Color(red: 1.0, green: 0.35, blue: 0.32)
+        case .pomodoro(.work):
+            return Color(red: 1.0, green: 0.38, blue: 0.32)
+        case .pomodoro(.shortBreak):
+            return Color(red: 0.35, green: 0.82, blue: 0.55)
+        case .pomodoro(.longBreak):
+            return Color(red: 0.40, green: 0.62, blue: 1.0)
         }
     }
 
@@ -149,6 +161,10 @@ struct NotchContentView: View {
             Text(vm.pomodoro.clock)
                 .font(.system(size: 10, weight: .medium).monospacedDigit())
                 .foregroundStyle(vm.pomodoro.isRunning ? Color.white.opacity(0.8) : Theme.tertiary)
+        case .memory:
+            Circle()
+                .fill(MemoryPane.color(for: vm.memory.level))
+                .frame(width: 7, height: 7)
         case .settings:
             EmptyView()
         }
@@ -217,11 +233,23 @@ struct NotchContentView: View {
         case .teleprompter:
             TeleprompterPane(prompter: vm.teleprompter, wantsKeyboard: $vm.wantsKeyboard)
         case .credits:
-            CreditsPane(usage: vm.usage, codex: vm.codex, cursor: vm.cursor)
+            CreditsPane(usage: vm.usage, codex: vm.codex, cursor: vm.cursor, providers: vm.usageProviders)
         case .pomodoro:
             PomodoroPane(pomodoro: vm.pomodoro)
+        case .memory:
+            MemoryPane(memory: vm.memory, cleanup: vm.cleanup)
         case .settings:
-            SettingsPane(shelf: vm.shelf, sleepManager: vm.sleepManager)
+            SettingsPane(
+                shelf: vm.shelf,
+                sleepManager: vm.sleepManager,
+                memory: vm.memory,
+                usageProviders: vm.usageProviders,
+                compact: true,
+                onOpenFull: { vm.onOpenFullSettings?() },
+                onPreviewYellow: { vm.previewMemoryWarn() },
+                onPreviewRed: { vm.previewMemoryCritical() },
+                onPreviewMeeting: { vm.previewMeeting() }
+            )
         }
     }
 }
@@ -268,7 +296,7 @@ private struct Rail: View {
                 } label: {
                     Image(systemName: tab.symbol)
                         .font(.system(size: 12, weight: .medium))
-                        .frame(width: 30, height: vm.geometry.railIconHeight)
+                        .frame(width: 30, height: vm.geometry.railIconHeight(forIconCount: NotchViewModel.Tab.leftRail.count))
                         .background(
                             RoundedRectangle(cornerRadius: 7, style: .continuous)
                                 .fill(fill(for: tab))

--- a/Sources/Cyclop/UI/NotchContentView.swift
+++ b/Sources/Cyclop/UI/NotchContentView.swift
@@ -166,7 +166,7 @@ struct NotchContentView: View {
         case .teleprompter:
             TeleprompterPane(prompter: vm.teleprompter, wantsKeyboard: $vm.wantsKeyboard)
         case .settings:
-            SettingsPane(shelf: vm.shelf)
+            SettingsPane(shelf: vm.shelf, sleepManager: vm.sleepManager)
         }
     }
 }

--- a/Sources/Cyclop/UI/NotchContentView.swift
+++ b/Sources/Cyclop/UI/NotchContentView.swift
@@ -98,6 +98,8 @@ struct NotchContentView: View {
             NotesCounter(notes: vm.notes)
         case .teleprompter:
             EmptyView()
+        case .credits:
+            EmptyView()
         case .settings:
             EmptyView()
         }
@@ -165,6 +167,8 @@ struct NotchContentView: View {
             NotesPane(notes: vm.notes, privacy: vm.privacy, wantsKeyboard: $vm.wantsKeyboard)
         case .teleprompter:
             TeleprompterPane(prompter: vm.teleprompter, wantsKeyboard: $vm.wantsKeyboard)
+        case .credits:
+            CreditsPane(usage: vm.usage, codex: vm.codex, cursor: vm.cursor)
         case .settings:
             SettingsPane(shelf: vm.shelf)
         }

--- a/Sources/Cyclop/UI/NotchContentView.swift
+++ b/Sources/Cyclop/UI/NotchContentView.swift
@@ -10,14 +10,43 @@ struct NotchContentView: View {
     var body: some View {
         // The shape is wider than the body by `topRadius` on each side: that
         // slack is where the concave shoulders live, so it must not be clipped.
+        let shape = NotchShape(
+            topRadius: topRadius,
+            bottomRadius: isOpen ? Theme.openBottomRadius : Theme.collapsedBottomRadius
+        )
+        let shapeWidth = size.width + 2 * topRadius
+        let rim = isOpen ? nil : Self.rimColor(for: vm.pomodoro.collapsedRimPhase)
+        // Collapsed, paint a hair past the reported notch: `auxiliaryTop*Area`
+        // width is occasionally a point shy of the cutout the eye reads, and a
+        // stroke on that tight box looked biased to one side.
+        let islandWidth = shapeWidth + (isOpen ? 0 : 2)
+        let rimThickness: CGFloat = 1.5
+        let rimPad: CGFloat = rim == nil ? 0 : rimThickness + 2
+
         ZStack(alignment: .top) {
-            NotchShape(
-                topRadius: topRadius,
-                bottomRadius: isOpen ? Theme.openBottomRadius : Theme.collapsedBottomRadius
-            )
-            .fill(Color.black)
-            .frame(width: size.width + 2 * topRadius, height: size.height)
-            .shadow(color: .black.opacity(isOpen ? 0.5 : 0), radius: 18, y: 8)
+            if let rim {
+                // Plate behind the island, same path, evenly larger — uniform
+                // on left/right/bottom. A stroked+blurred path was what made
+                // one side look tighter than the other.
+                shape
+                    .fill(rim.opacity(0.45))
+                    .frame(
+                        width: islandWidth + 2 * (rimThickness + 1),
+                        height: size.height + rimThickness + 1
+                    )
+                    .blur(radius: 1.2)
+                shape
+                    .fill(rim)
+                    .frame(
+                        width: islandWidth + 2 * rimThickness,
+                        height: size.height + rimThickness
+                    )
+            }
+
+            shape
+                .fill(Color.black)
+                .frame(width: islandWidth, height: size.height)
+                .shadow(color: .black.opacity(isOpen ? 0.5 : 0), radius: 18, y: 8)
 
             VStack(spacing: 0) {
                 header
@@ -29,10 +58,26 @@ struct NotchContentView: View {
             .frame(width: size.width, height: size.height, alignment: .top)
             .clipped()
         }
-        .frame(width: size.width + 2 * topRadius, height: size.height, alignment: .top)
+        .frame(
+            width: islandWidth + 2 * rimPad,
+            height: size.height + rimPad,
+            alignment: .top
+        )
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .animation(Theme.openAnimation, value: isOpen)
         .animation(Theme.paneAnimation, value: vm.tab)
+        .animation(.easeInOut(duration: 0.35), value: vm.pomodoro.collapsedRimPhase)
+    }
+
+    /// Coral while focusing, mint on a short break, blue on a long one —
+    /// readable at a glance from across the desk.
+    private static func rimColor(for phase: PomodoroStore.Phase?) -> Color? {
+        switch phase {
+        case .work: return Color(red: 1.0, green: 0.38, blue: 0.32)
+        case .shortBreak: return Color(red: 0.35, green: 0.82, blue: 0.55)
+        case .longBreak: return Color(red: 0.40, green: 0.62, blue: 1.0)
+        case nil: return nil
+        }
     }
 
     // MARK: - Header
@@ -98,6 +143,10 @@ struct NotchContentView: View {
             NotesCounter(notes: vm.notes)
         case .teleprompter:
             EmptyView()
+        case .pomodoro:
+            Text(vm.pomodoro.clock)
+                .font(.system(size: 10, weight: .medium).monospacedDigit())
+                .foregroundStyle(vm.pomodoro.isRunning ? Color.white.opacity(0.8) : Theme.tertiary)
         case .settings:
             EmptyView()
         }
@@ -165,6 +214,8 @@ struct NotchContentView: View {
             NotesPane(notes: vm.notes, privacy: vm.privacy, wantsKeyboard: $vm.wantsKeyboard)
         case .teleprompter:
             TeleprompterPane(prompter: vm.teleprompter, wantsKeyboard: $vm.wantsKeyboard)
+        case .pomodoro:
+            PomodoroPane(pomodoro: vm.pomodoro)
         case .settings:
             SettingsPane(shelf: vm.shelf)
         }

--- a/Sources/Cyclop/UI/PomodoroPane.swift
+++ b/Sources/Cyclop/UI/PomodoroPane.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+struct PomodoroPane: View {
+    @ObservedObject var pomodoro: PomodoroStore
+
+    var body: some View {
+        VStack(spacing: 10) {
+            presets
+            clock
+            controls
+            steppers
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Presets
+
+    private var presets: some View {
+        HStack(spacing: 6) {
+            ForEach(PomodoroStore.Preset.allCases) { preset in
+                Button {
+                    pomodoro.selectPreset(preset)
+                } label: {
+                    Text(title(for: preset))
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(pomodoro.preset == preset ? .white : Theme.secondary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(
+                            Capsule().fill(
+                                pomodoro.preset == preset ? Theme.surfaceHover : Theme.surface
+                            )
+                        )
+                        .contentShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    // MARK: - Clock
+
+    private var clock: some View {
+        VStack(spacing: 6) {
+            Text(pomodoro.phaseTitle.uppercased())
+                .font(.system(size: 10, weight: .semibold))
+                .tracking(0.8)
+                .foregroundStyle(Theme.tertiary)
+
+            Text(pomodoro.clock)
+                .font(.system(size: 44, weight: .medium, design: .rounded).monospacedDigit())
+                .foregroundStyle(.white)
+                .contentTransition(.numericText())
+                .animation(.linear(duration: 0.2), value: pomodoro.clock)
+
+            HStack(spacing: 5) {
+                ForEach(0..<PomodoroStore.roundsUntilLongBreak, id: \.self) { index in
+                    Circle()
+                        .fill(index < pomodoro.roundIndexInSet ? Color.white.opacity(0.85) : Theme.hairline)
+                        .frame(width: 6, height: 6)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Transport
+
+    private var controls: some View {
+        HStack(spacing: 14) {
+            Button { pomodoro.reset() } label: {
+                Image(systemName: "arrow.counterclockwise")
+            }
+            .buttonStyle(NotchButtonStyle(size: 30))
+            .help(localized("Reset"))
+
+            Button { pomodoro.toggle() } label: {
+                Image(systemName: pomodoro.isRunning ? "pause.fill" : "play.fill")
+            }
+            .buttonStyle(NotchButtonStyle(size: 40, prominent: true))
+
+            Button { pomodoro.skip() } label: {
+                Image(systemName: "forward.fill")
+            }
+            .buttonStyle(NotchButtonStyle(size: 30))
+            .help(localized("Skip"))
+        }
+    }
+
+    // MARK: - Durations
+
+    private var steppers: some View {
+        HStack(spacing: 14) {
+            stepper(
+                label: localized("Focus"),
+                value: pomodoro.workMinutes,
+                decrement: { pomodoro.adjustWork(by: -1) },
+                increment: { pomodoro.adjustWork(by: 1) }
+            )
+            stepper(
+                label: localized("Break"),
+                value: pomodoro.shortBreakMinutes,
+                decrement: { pomodoro.adjustShortBreak(by: -1) },
+                increment: { pomodoro.adjustShortBreak(by: 1) }
+            )
+            stepper(
+                label: localized("Long"),
+                value: pomodoro.longBreakMinutes,
+                decrement: { pomodoro.adjustLongBreak(by: -1) },
+                increment: { pomodoro.adjustLongBreak(by: 1) }
+            )
+        }
+    }
+
+    private func stepper(
+        label: String,
+        value: Int,
+        decrement: @escaping () -> Void,
+        increment: @escaping () -> Void
+    ) -> some View {
+        VStack(spacing: 4) {
+            Text(label)
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(Theme.tertiary)
+            HStack(spacing: 6) {
+                Button(action: decrement) {
+                    Image(systemName: "minus")
+                        .font(.system(size: 9, weight: .semibold))
+                        .frame(width: 20, height: 20)
+                        .background(Circle().fill(Theme.surface))
+                }
+                .buttonStyle(.plain)
+
+                Text("\(value)")
+                    .font(.system(size: 12, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(.white)
+                    .frame(minWidth: 18)
+
+                Button(action: increment) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 9, weight: .semibold))
+                        .frame(width: 20, height: 20)
+                        .background(Circle().fill(Theme.surface))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func title(for preset: PomodoroStore.Preset) -> String {
+        switch preset {
+        case .classic: return localized("Classic")
+        case .short: return localized("Short")
+        case .long: return localized("Long")
+        case .custom: return localized("Custom")
+        }
+    }
+}

--- a/Sources/Cyclop/UI/SettingsPane.swift
+++ b/Sources/Cyclop/UI/SettingsPane.swift
@@ -9,6 +9,13 @@ import ServiceManagement
 struct SettingsPane: View {
     @ObservedObject var shelf: ShelfStore
     @ObservedObject var sleepManager: SleepManager
+    @ObservedObject var memory: MemoryPressureStore
+    @ObservedObject var usageProviders: UsageProviderSettings
+    var compact: Bool = true
+    var onOpenFull: (() -> Void)? = nil
+    var onPreviewYellow: () -> Void
+    var onPreviewRed: () -> Void
+    var onPreviewMeeting: () -> Void
 
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var saveClipboardImages = NotchViewModel.saveClipboardImagesEnabled
@@ -30,6 +37,31 @@ struct SettingsPane: View {
                     )
                 }
 
+                section(localized("Usage")) {
+                    ForEach(UsageProvider.allCases) { provider in
+                        toggleRow(
+                            symbol: provider.symbol,
+                            title: provider.title,
+                            isOn: Binding(
+                                get: { usageProviders.isEnabled(provider) },
+                                set: { usageProviders.setEnabled(provider, $0) }
+                            )
+                        )
+                    }
+                }
+
+                if compact {
+                    actionRow(symbol: "slider.horizontal.3", title: localized("All Settings…")) {
+                        onOpenFull?()
+                    }
+                    .padding(4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(Theme.surface)
+                    )
+                }
+
+                if !compact {
                 section(localized("Screenshots")) {
                     toggleRow(
                         symbol: "photo.on.rectangle",
@@ -54,10 +86,58 @@ struct SettingsPane: View {
                     }
                 }
 
+                section(localized("Memory glow")) {
+                    toggleRow(
+                        symbol: "percent",
+                        title: localized("Also glow from RAM used"),
+                        isOn: glowFromPercentBinding
+                    )
+                    HStack(spacing: 8) {
+                        glowStepper(
+                            symbol: "circle.fill",
+                            tint: Color(red: 1.0, green: 0.78, blue: 0.20),
+                            title: localized("Yellow at"),
+                            value: memory.yellowThreshold,
+                            decrement: { memory.adjustYellow(by: -5) },
+                            increment: { memory.adjustYellow(by: 5) }
+                        )
+                        glowStepper(
+                            symbol: "circle.fill",
+                            tint: Color(red: 1.0, green: 0.35, blue: 0.32),
+                            title: localized("Red at"),
+                            value: memory.redThreshold,
+                            decrement: { memory.adjustRed(by: -5) },
+                            increment: { memory.adjustRed(by: 5) }
+                        )
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .opacity(memory.glowFromPercent ? 1 : 0.4)
+                    .disabled(!memory.glowFromPercent)
+                    Text(localized("Notch glows only when the graph is red."))
+                        .font(.system(size: 9.5))
+                        .foregroundStyle(Theme.tertiary)
+                        .padding(.horizontal, 8)
+                        .padding(.bottom, 6)
+                }
+
+                section(localized("Preview glow")) {
+                    actionRow(symbol: "circle.fill", title: localized("Preview yellow")) {
+                        onPreviewYellow()
+                    }
+                    actionRow(symbol: "circle.fill", title: localized("Preview red")) {
+                        onPreviewRed()
+                    }
+                    actionRow(symbol: "sparkle", title: localized("Preview meeting")) {
+                        onPreviewMeeting()
+                    }
+                }
+
                 section(localized("Snippets")) {
                     actionRow(symbol: "doc.text", title: localized("Show Snippets File")) {
                         SnippetStore.reveal()
                     }
+                }
                 }
             }
             .padding(.top, 2)
@@ -103,6 +183,13 @@ struct SettingsPane: View {
         Binding(
             get: { sleepManager.isEnabled },
             set: { sleepManager.setEnabled($0) }
+        )
+    }
+
+    private var glowFromPercentBinding: Binding<Bool> {
+        Binding(
+            get: { memory.glowFromPercent },
+            set: { memory.setGlowFromPercent($0) }
         )
     }
 
@@ -163,6 +250,47 @@ struct SettingsPane: View {
         }
         .padding(.horizontal, 8)
         .frame(height: 26)
+    }
+
+    private func glowStepper(
+        symbol: String,
+        tint: Color,
+        title: String,
+        value: Int,
+        decrement: @escaping () -> Void,
+        increment: @escaping () -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Image(systemName: symbol)
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(tint)
+                Text(title)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(Theme.tertiary)
+            }
+            HStack(spacing: 6) {
+                Button(action: decrement) {
+                    Image(systemName: "minus")
+                        .font(.system(size: 9, weight: .semibold))
+                        .frame(width: 20, height: 20)
+                        .background(Circle().fill(Theme.surfaceHover))
+                }
+                .buttonStyle(.plain)
+                Text("\(value)%")
+                    .font(.system(size: 12, weight: .semibold).monospacedDigit())
+                    .foregroundStyle(.white)
+                    .frame(minWidth: 36)
+                Button(action: increment) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 9, weight: .semibold))
+                        .frame(width: 20, height: 20)
+                        .background(Circle().fill(Theme.surfaceHover))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func actionRow(

--- a/Sources/Cyclop/UI/SettingsPane.swift
+++ b/Sources/Cyclop/UI/SettingsPane.swift
@@ -8,6 +8,7 @@ import ServiceManagement
 /// other than as a menu that grows a new row per feature.
 struct SettingsPane: View {
     @ObservedObject var shelf: ShelfStore
+    @ObservedObject var sleepManager: SleepManager
 
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var saveClipboardImages = NotchViewModel.saveClipboardImagesEnabled
@@ -21,6 +22,11 @@ struct SettingsPane: View {
                         symbol: "arrow.forward.to.line",
                         title: localized("Launch at Login"),
                         isOn: launchAtLoginBinding
+                    )
+                    toggleRow(
+                        symbol: "cup.and.saucer.fill",
+                        title: localized("Keep Awake with Lid Closed"),
+                        isOn: keepAwakeBinding
                     )
                 }
 
@@ -90,6 +96,13 @@ struct SettingsPane: View {
                 }
                 launchAtLogin = SMAppService.mainApp.status == .enabled
             }
+        )
+    }
+
+    private var keepAwakeBinding: Binding<Bool> {
+        Binding(
+            get: { sleepManager.isEnabled },
+            set: { sleepManager.setEnabled($0) }
         )
     }
 

--- a/Sources/Cyclop/UI/SettingsWindow.swift
+++ b/Sources/Cyclop/UI/SettingsWindow.swift
@@ -1,0 +1,59 @@
+import AppKit
+import SwiftUI
+
+struct SettingsWindowRoot: View {
+    @ObservedObject var vm: NotchViewModel
+
+    var body: some View {
+        SettingsPane(
+            shelf: vm.shelf,
+            sleepManager: vm.sleepManager,
+            memory: vm.memory,
+            usageProviders: vm.usageProviders,
+            compact: false,
+            onPreviewYellow: { vm.previewMemoryWarn() },
+            onPreviewRed: { vm.previewMemoryCritical() },
+            onPreviewMeeting: { vm.previewMeeting() }
+        )
+        .padding(16)
+        .frame(minWidth: 380, minHeight: 520, alignment: .topLeading)
+        .background(Color.black)
+    }
+}
+
+@MainActor
+final class SettingsWindowController: NSWindowController {
+    private var hosting: NSHostingView<SettingsWindowRoot>?
+    private var didPlace = false
+
+    convenience init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 580),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = localized("Settings")
+        window.isReleasedWhenClosed = false
+        window.appearance = NSAppearance(named: .darkAqua)
+        window.backgroundColor = .black
+        self.init(window: window)
+    }
+
+    func present(vm: NotchViewModel) {
+        let root = SettingsWindowRoot(vm: vm)
+        if let hosting {
+            hosting.rootView = root
+        } else {
+            let view = NSHostingView(rootView: root)
+            hosting = view
+            window?.contentView = view
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        window?.makeKeyAndOrderFront(nil)
+        if !didPlace {
+            window?.center()
+            didPlace = true
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Вкладка Memory показывает то же давление, что Activity Monitor (зелёный / жёлтый / красный), плюс очистку кэшей.
- Вырез светится только на красном (jetsam 3+); жёлтый на графике — рабочий фон, особенно на 16 ГБ. Опционально — свечение от процента RAM (выкл. по умолчанию).
- Usage-карточки подстраиваются под включённых провайдеров; компактные настройки в вырезе, полное окно — через «Все настройки…» / ⌘,.

## Test plan
- [ ] Открыть вкладку Memory: график совпадает с Мониторингом системы
- [ ] На зелёном/жёлтом вырез тёмный; на красном — красное свечение
- [ ] Settings → Preview red / yellow / meeting
- [ ] Cleanup: scan, confirm, Full Disk Access empty state
- [ ] Usage: 1/2/3 карточки, высота панели по рядам
- [ ] ⌘, открывает окно настроек и сворачивает вырез


Made with [Cursor](https://cursor.com)