### PR TITLE
Настройки собраны в config.json рядом со snippets.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Sources/Cyclop
 │   ├── ClipboardStore.swift
 │   ├── ScreenshotVault.swift  clipboard screenshots onto disk
 │   ├── SnippetStore.swift     snippets: reading and writing snippets.json
+│   ├── ConfigStore.swift      settings: reading and writing config.json
 │   ├── NoteStore.swift        scratch notes: notes.json
 │   ├── PrivacyMode.swift      hiding contents: sections and reveals
 │   ├── Translator.swift       Translation.framework, direction by script

--- a/README.ru.md
+++ b/README.ru.md
@@ -474,6 +474,7 @@ Sources/Cyclop
 │   ├── ClipboardStore.swift
 │   ├── ScreenshotVault.swift  снимки из буфера на диск
 │   ├── SnippetStore.swift     заготовки: чтение и запись snippets.json
+│   ├── ConfigStore.swift      настройки: чтение и запись config.json
 │   ├── NoteStore.swift        временные заметки: notes.json
 │   ├── PrivacyMode.swift      скрытие содержимого: разделы и раскрытия
 │   ├── Translator.swift       Translation.framework, направление по письменности

--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -35,6 +35,10 @@
 "Clear Screenshots Folder (%@)" = "Clear Screenshots Folder (%@)";
 "Show Snippets File" = "Show Snippets File";
 
+"Configuration" = "Configuration";
+"Show Config File" = "Show Config File";
+"config.json is broken — click to open; nothing is overwritten" = "config.json is broken — click to open; nothing is overwritten";
+
 "Cyclop" = "Cyclop";
 "Quit Cyclop" = "Quit Cyclop";
 

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -34,6 +34,10 @@
 "Clear Screenshots Folder (%@)" = "Очистить папку снимков (%@)";
 "Show Snippets File" = "Показать файл заготовок";
 
+"Configuration" = "Конфигурация";
+"Show Config File" = "Показать файл конфигурации";
+"config.json is broken — click to open; nothing is overwritten" = "config.json не читается — нажми, чтобы открыть; поверх ничего не пишется";
+
 "Cyclop" = "Cyclop";
 "Quit Cyclop" = "Выйти из Cyclop";
 

--- a/Sources/Cyclop/Model/NotchViewModel.swift
+++ b/Sources/Cyclop/Model/NotchViewModel.swift
@@ -83,12 +83,12 @@ final class NotchViewModel: ObservableObject {
     ///
     /// Kept as the set of what is off rather than what is on, so a tab added
     /// in a later version shows up for everyone instead of arriving hidden.
-    static let hiddenTabsKey = "hiddenTabs"
-
+    /// Persisted in `config.json` (#67), alongside the rest of what makes
+    /// sense on another Mac.
     @Published private(set) var hiddenTabs: Set<Tab> = NotchViewModel.loadHiddenTabs()
 
     private static func loadHiddenTabs() -> Set<Tab> {
-        let raw = UserDefaults.standard.stringArray(forKey: hiddenTabsKey) ?? []
+        let raw = ConfigStore.shared.hiddenTabs
         return Set(raw.compactMap(Tab.init(rawValue:))).filter(\.canHide)
     }
 
@@ -114,7 +114,7 @@ final class NotchViewModel: ObservableObject {
             // means, the teleprompter's suspend included.
             if tab == target { tab = firstVisibleTab }
         }
-        UserDefaults.standard.set(hiddenTabs.map(\.rawValue).sorted(), forKey: Self.hiddenTabsKey)
+        ConfigStore.shared.hiddenTabs = hiddenTabs.map(\.rawValue).sorted()
     }
 
     /// What a tab keeps running while nobody is looking at it. Only a few have
@@ -282,14 +282,12 @@ final class NotchViewModel: ObservableObject {
         }
     }
 
-    /// Off switch for people who copy images all day and do not want them kept.
-    static let saveClipboardImagesKey = "saveClipboardImages"
-
-    /// Defaults to on: the feature is the reason the folder exists.
+    /// Off switch for people who copy images all day and do not want them
+    /// kept. Persisted in `config.json` (#67) — see
+    /// `ConfigStore.saveClipboardImages` for the default.
     static var saveClipboardImagesEnabled: Bool {
-        let defaults = UserDefaults.standard
-        guard defaults.object(forKey: saveClipboardImagesKey) != nil else { return true }
-        return defaults.bool(forKey: saveClipboardImagesKey)
+        get { ConfigStore.shared.saveClipboardImages }
+        set { ConfigStore.shared.saveClipboardImages = newValue }
     }
 
     func start() {

--- a/Sources/Cyclop/Model/PrivacyMode.swift
+++ b/Sources/Cyclop/Model/PrivacyMode.swift
@@ -36,29 +36,19 @@ final class PrivacyMode: ObservableObject {
         }
     }
 
-    static let key = "privacyMode.sections"
-    /// What the first version of this stored: one bool for everything. Read
-    /// once, so a panel that was already covering keeps covering after an
-    /// update instead of quietly opening up.
-    static let legacyKey = "privacyMode"
-
-    @Published private(set) var sections: Set<Section>
-
     /// What the user has uncovered by hand, by row id. Cleared whenever the
     /// panel folds: a row uncovered once must not still be uncovered the next
     /// time the panel opens, which would be exactly when nobody is looking at
     /// it and the camera is.
     @Published private(set) var revealed: Set<String> = []
 
+    @Published private(set) var sections: Set<Section>
+
+    /// Persisted in `config.json` (#67) — the old `UserDefaults` keys, one
+    /// bool for everything and then one array of sections, were folded into
+    /// it once and are no longer read here.
     init() {
-        let defaults = UserDefaults.standard
-        if let stored = defaults.array(forKey: Self.key) as? [String] {
-            sections = Set(stored.compactMap(Section.init(rawValue:)))
-        } else if defaults.bool(forKey: Self.legacyKey) {
-            sections = Set(Section.allCases)
-        } else {
-            sections = []
-        }
+        sections = Set(ConfigStore.shared.privacy.compactMap(Section.init(rawValue:)))
     }
 
     // MARK: - Sections
@@ -83,10 +73,7 @@ final class PrivacyMode: ObservableObject {
     }
 
     private func persist() {
-        UserDefaults.standard.set(sections.map(\.rawValue).sorted(), forKey: Self.key)
-        // Kept in step so that rolling back to an older build finds the switch
-        // where it left it, rather than off.
-        UserDefaults.standard.set(coversAny, forKey: Self.legacyKey)
+        ConfigStore.shared.privacy = sections.map(\.rawValue).sorted()
         if !coversAny { revealed.removeAll() }
     }
 

--- a/Sources/Cyclop/Notch/NotchGeometry.swift
+++ b/Sources/Cyclop/Notch/NotchGeometry.swift
@@ -88,22 +88,17 @@ struct NotchGeometry {
     /// `NSScreen.screens` is not, because that array reorders too.
     var displayID: CGDirectDisplayID? { screen.displayID }
 
-    /// Persisted switch for every display past the first. Defaults to on: the
-    /// panel is meant to be wherever the pointer is, so this is the way to
-    /// pull it back to one screen, not the way to ask for the rest.
-    static let allDisplaysKey = "showOnAllDisplays"
     /// Posted when that switch changes, so the panels are rebuilt at once
     /// rather than at the next relaunch.
     static let allDisplaysChanged = Notification.Name("CyclopShowOnAllDisplaysChanged")
 
+    /// Persisted in `config.json` (#67) — see `ConfigStore.showOnAllDisplays`
+    /// for the default and the reason for it.
+    @MainActor
     static var showsOnAllDisplays: Bool {
-        get {
-            let defaults = UserDefaults.standard
-            guard defaults.object(forKey: allDisplaysKey) != nil else { return true }
-            return defaults.bool(forKey: allDisplaysKey)
-        }
+        get { ConfigStore.shared.showOnAllDisplays }
         set {
-            UserDefaults.standard.set(newValue, forKey: allDisplaysKey)
+            ConfigStore.shared.showOnAllDisplays = newValue
             NotificationCenter.default.post(name: allDisplaysChanged, object: nil)
         }
     }
@@ -113,6 +108,7 @@ struct NotchGeometry {
     /// Switched off, that is the screen with a physical notch if one is
     /// attached and the main display otherwise — the rule from before there
     /// was more than one screen to choose between.
+    @MainActor
     static func all() -> [NotchGeometry] {
         // A mirrored display repeats another one's picture, so a panel of its
         // own would be a second copy of the same notch, drawn in the same

--- a/Sources/Cyclop/Services/ConfigStore.swift
+++ b/Sources/Cyclop/Services/ConfigStore.swift
@@ -1,0 +1,169 @@
+import AppKit
+
+/// Everything about Cyclop that makes sense on somebody else's Mac, in one
+/// file next to `snippets.json` and `notes.json` (#67).
+///
+/// Before this, the same handful of settings each kept their own place and
+/// their own copy of "and what if the key isn't there yet": `showOnAllDisplays`
+/// in `NotchGeometry`, `saveClipboardImages` in `NotchViewModel`, the privacy
+/// sections in `PrivacyMode`, the teleprompter's speed and font size in
+/// `TeleprompterStore`, and, freshest, the tab switches from #80. Harmless at
+/// four; every new setting was the fifth spelling of the same question.
+///
+/// **What comes here.** What has meaning on another Mac. Shelf paths (content,
+/// not configuration) and calendar overrides (tied to calendar identifiers on
+/// this particular Mac) stay in `UserDefaults` — see #67 for the rule.
+///
+/// **Migration.** No file yet → built once from the old `UserDefaults` keys
+/// and written. The old keys are then left alone: rolling back to a build
+/// before this one loses a few switches rather than this app carrying two
+/// sources of truth for one release (decided in #67).
+@MainActor
+final class ConfigStore: ObservableObject {
+    private struct Teleprompter: Codable, Equatable {
+        var speed: Double = 1
+        var fontSize: Double = 30
+    }
+
+    private struct File: Codable, Equatable {
+        var showOnAllDisplays = true
+        var saveClipboardImages = true
+        var privacy: [String] = []
+        var teleprompter = Teleprompter()
+        var hiddenTabs: [String] = []
+    }
+
+    static let shared = ConfigStore()
+
+    /// `~/Library/Application Support/Cyclop/config.json`.
+    static let file = Support.file("config.json")
+
+    /// True when the file exists but cannot be parsed — same meaning and the
+    /// same consequence as `SnippetStore.fileBroken` (#7): reading stays
+    /// honest, and writing stops rather than paving over a hand edit gone
+    /// wrong.
+    @Published private(set) var fileBroken = false
+
+    private var value: File
+
+    private init() {
+        if let data = try? Data(contentsOf: Self.file) {
+            do {
+                value = try JSONDecoder().decode(File.self, from: data)
+            } catch {
+                value = File()
+                fileBroken = true
+                NSLog("Cyclop: config.json is not readable: \(error.localizedDescription)")
+            }
+        } else {
+            // Nothing on disk yet, so nothing to protect — assembled from
+            // whatever the old keys already say and written straight away.
+            value = Self.migrated()
+            write(value)
+        }
+    }
+
+    // MARK: - Settings
+
+    /// Persisted switch for every display past the first. Defaults to on: the
+    /// panel is meant to be wherever the pointer is, so this is the way to
+    /// pull it back to one screen, not the way to ask for the rest.
+    var showOnAllDisplays: Bool {
+        get { value.showOnAllDisplays }
+        set { value.showOnAllDisplays = newValue; persist() }
+    }
+
+    /// Off switch for people who copy images all day and do not want them
+    /// kept. Defaults to on: the feature is the reason the folder exists.
+    var saveClipboardImages: Bool {
+        get { value.saveClipboardImages }
+        set { value.saveClipboardImages = newValue; persist() }
+    }
+
+    /// Raw `PrivacyMode.Section` values. Kept as strings here rather than that
+    /// type so this store does not need to know about it — the same reason
+    /// `hiddenTabs` below is `[String]` and not `[NotchViewModel.Tab]`.
+    var privacy: [String] {
+        get { value.privacy }
+        set { value.privacy = newValue; persist() }
+    }
+
+    var teleprompterSpeed: Double {
+        get { value.teleprompter.speed }
+        set { value.teleprompter.speed = newValue; persist() }
+    }
+
+    var teleprompterFontSize: Double {
+        get { value.teleprompter.fontSize }
+        set { value.teleprompter.fontSize = newValue; persist() }
+    }
+
+    /// Tabs switched off in Settings (#80), by `Tab.rawValue`. Kept as the set
+    /// of what is off rather than what is on, so a tab added in a later
+    /// version shows up for everyone instead of arriving hidden.
+    var hiddenTabs: [String] {
+        get { value.hiddenTabs }
+        set { value.hiddenTabs = newValue; persist() }
+    }
+
+    // MARK: - Migration
+
+    /// Reads the five places these settings used to live. Each guard mirrors
+    /// exactly what that setting's own `object(forKey:) != nil` check used to
+    /// do, so a Mac with none of these keys set gets the same defaults as
+    /// before and a Mac with some of them set keeps exactly those.
+    private static func migrated() -> File {
+        let defaults = UserDefaults.standard
+        var file = File()
+        if defaults.object(forKey: "showOnAllDisplays") != nil {
+            file.showOnAllDisplays = defaults.bool(forKey: "showOnAllDisplays")
+        }
+        if defaults.object(forKey: "saveClipboardImages") != nil {
+            file.saveClipboardImages = defaults.bool(forKey: "saveClipboardImages")
+        }
+        if let sections = defaults.array(forKey: "privacyMode.sections") as? [String] {
+            file.privacy = sections
+        } else if defaults.bool(forKey: "privacyMode") {
+            // The legacy switch covered everything or nothing — see
+            // `PrivacyMode.init` before this store existed.
+            file.privacy = ["clipboard", "snippets", "calendar", "notes"]
+        }
+        if let speed = defaults.object(forKey: "teleprompter.speed") as? Double {
+            file.teleprompter.speed = speed
+        }
+        if let fontSize = defaults.object(forKey: "teleprompter.fontSize") as? Double {
+            file.teleprompter.fontSize = fontSize
+        }
+        if let hidden = defaults.stringArray(forKey: "hiddenTabs") {
+            file.hiddenTabs = hidden
+        }
+        return file
+    }
+
+    // MARK: - Storage
+
+    private func persist() {
+        write(value)
+    }
+
+    /// Pretty-printed, and slashes left alone — same reason as
+    /// `snippets.json`: this file is meant to be opened, edited by hand, and
+    /// handed to somebody else's Mac.
+    private func write(_ file: File) {
+        guard !fileBroken else { return }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .withoutEscapingSlashes]
+        do {
+            try encoder.encode(file).write(to: Self.file, options: .atomic)
+        } catch {
+            NSLog("Cyclop: cannot write config.json: \(error.localizedDescription)")
+        }
+    }
+
+    static func reveal() {
+        if !FileManager.default.fileExists(atPath: file.path) {
+            shared.write(shared.value)
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([file])
+    }
+}

--- a/Sources/Cyclop/Services/TeleprompterStore.swift
+++ b/Sources/Cyclop/Services/TeleprompterStore.swift
@@ -30,7 +30,7 @@ final class TeleprompterStore: ObservableObject {
     @Published var speed: Double = 1.0 {
         didSet {
             guard speed != oldValue else { return }
-            defaults.set(speed, forKey: Self.speedKey)
+            ConfigStore.shared.teleprompterSpeed = speed
         }
     }
 
@@ -40,7 +40,7 @@ final class TeleprompterStore: ObservableObject {
     @Published var fontSize: Double = 30 {
         didSet {
             guard fontSize != oldValue else { return }
-            defaults.set(fontSize, forKey: Self.fontKey)
+            ConfigStore.shared.teleprompterFontSize = fontSize
         }
     }
 
@@ -55,10 +55,6 @@ final class TeleprompterStore: ObservableObject {
     /// Height of the window the text scrolls through, also from the pane.
     var viewportHeight: CGFloat = 0
 
-    private static let speedKey = "teleprompter.speed"
-    private static let fontKey = "teleprompter.fontSize"
-    private let defaults = UserDefaults.standard
-
     private static let file = Support.file("teleprompter.txt")
 
     private var timer: Timer?
@@ -69,12 +65,11 @@ final class TeleprompterStore: ObservableObject {
         // Reading the file above went through `script`'s observer and armed a
         // save of what was just loaded. Harmless, but worth not doing.
         saves.cancel()
-        if let stored = defaults.object(forKey: Self.speedKey) as? Double {
-            speed = min(max(stored, 0.3), 3.0)
-        }
-        if let stored = defaults.object(forKey: Self.fontKey) as? Double {
-            fontSize = min(max(stored, 18), 64)
-        }
+        // Persisted in `config.json` (#67) since before this store existed —
+        // the clamps guard a value hand-edited in the file past what the
+        // slider itself allows.
+        speed = min(max(ConfigStore.shared.teleprompterSpeed, 0.3), 3.0)
+        fontSize = min(max(ConfigStore.shared.teleprompterFontSize, 18), 64)
     }
 
     // MARK: - Running

--- a/Sources/Cyclop/UI/SettingsPane.swift
+++ b/Sources/Cyclop/UI/SettingsPane.swift
@@ -10,6 +10,7 @@ struct SettingsPane: View {
     @ObservedObject var vm: NotchViewModel
     @ObservedObject var shelf: ShelfStore
     let screenshots: ScreenshotFolderWatcher
+    @ObservedObject private var config = ConfigStore.shared
 
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var menuBarIconVisible = AppDelegate.isMenuBarIconVisible
@@ -92,9 +93,20 @@ struct SettingsPane: View {
                     }
                 }
 
+                // What lives in this file is documented in #67: everything
+                // above that makes sense on another Mac, in one place instead
+                // of five.
+                section(localized("Configuration")) {
+                    if config.fileBroken { configBrokenNotice }
+                    actionRow(symbol: "gearshape", title: localized("Show Config File")) {
+                        ConfigStore.reveal()
+                    }
+                }
+
                 // The one door left once the menu bar icon is gone (#5): a
                 // status item is not required to hide it any more, so quitting
-                // must not require one either.
+                // must not require one either. Last on purpose — leaving is
+                // not something to meet on the way to a switch.
                 section(localized("Cyclop")) {
                     actionRow(symbol: "power", title: localized("Quit Cyclop")) {
                         NSApp.terminate(nil)
@@ -167,7 +179,7 @@ struct SettingsPane: View {
             get: { saveClipboardImages },
             set: { wants in
                 saveClipboardImages = wants
-                UserDefaults.standard.set(wants, forKey: NotchViewModel.saveClipboardImagesKey)
+                NotchViewModel.saveClipboardImagesEnabled = wants
             }
         )
     }
@@ -246,6 +258,26 @@ struct SettingsPane: View {
                 .toggleStyle(NotchToggleStyle())
                 .labelsHidden()
         }
+        .padding(.horizontal, 8)
+        .frame(height: 26)
+    }
+
+    /// The refusal to write over a broken file (#7) is only honest if it is
+    /// said out loud — same reasoning as `SnippetsPane.brokenNotice`.
+    private var configBrokenNotice: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(Color.yellow.opacity(0.85))
+            Text(localized("config.json is broken — click to open; nothing is overwritten"))
+                .font(.system(size: 10))
+                .foregroundStyle(Theme.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .onTapGesture { ConfigStore.reveal() }
         .padding(.horizontal, 8)
         .frame(height: 26)
     }


### PR DESCRIPTION
Реализация #67 по договорённости в его комментарии: только переносимое (полка и календари остаются в `UserDefaults`), без дублирования (файла нет — собрали разово из старых ключей, дальше их не трогаем).

**Что уехало в `config.json`.**

| Настройка | Было |
|---|---|
| `showOnAllDisplays` | `NotchGeometry`, UserDefaults |
| `saveClipboardImages` | `NotchViewModel`, UserDefaults |
| `privacy` | `PrivacyMode.sections` + легаси-бул `privacyMode` |
| `teleprompter.speed`, `teleprompter.fontSize` | `TeleprompterStore`, UserDefaults |
| `hiddenTabs` | из #80, UserDefaults |

Пример файла ровно как в issue:
```json
{
  "showOnAllDisplays": true,
  "saveClipboardImages": true,
  "privacy": ["clipboard", "notes"],
  "teleprompter": { "speed": 1, "fontSize": 30 },
  "hiddenTabs": []
}
```

**Механика.** `ConfigStore`, тем же приёмом, что `SnippetStore`: `Support.file("config.json")`, pretty print, слэши не экранируются, `fileBroken` — файл, который не читается, не перезаписывается (#7).

**Миграция.** Файла нет → читаем ровно те пять старых ключей (каждый своим прежним правилом на «а если ключа нет») → пишем. Старые ключи после этого не трогаем.

**Кстати:** `PrivacyMode.persist` держал легаси-ключ в шаге ради отката на старую сборку — этот смысл ушёл вместе с переездом, комментарий переписан.

**Вкладка настроек.** Новая секция «Configuration»: кнопка показать файл в Finder и то же предупреждение о поломке, что у заготовок.

Тестов нет — не обязательно по твоему комментарию, и #65 отдельной задачей. Проверено сборкой; вручную можно быстрым чек-листом: свежий профиль без файла → мигрирует и создаёт config.json → потрогать каждый тумблер → значения совпадают с файлом на диске.

```
./Scripts/bundle.sh release   ✓
./Scripts/test-helper.sh      ✓
проверка ключей перевода      ✓
```
