### PR TITLE
Синтетическая чёлка на внешнем дисплее больше не считает свою пустоту доказательством пустого бара

### DIFF
--- a/Sources/Cyclop/Notch/NotchGeometry.swift
+++ b/Sources/Cyclop/Notch/NotchGeometry.swift
@@ -173,10 +173,17 @@ struct NotchGeometry {
         let leftmost = icons.filter(bar.intersects).map(\.minX).min()
         // The right edge of the collapsed target, icons permitting.
         let reach = screen.frame.midX + 90 + 6
-        // An empty scan is not evidence of an empty menu bar — Control Center
-        // alone puts several windows up there — so it reads as "could not
-        // measure", and the cautious strip is what that falls back to.
-        let crowded = icons.isEmpty || (leftmost ?? .infinity) < reach
+        // No icon measured on *this* bar reads as "could not measure",
+        // whatever the reason: a globally empty scan (Control Center alone
+        // puts several windows up there), or — with Spaces on — macOS drawing
+        // status items only on the bar of the display currently focused, so
+        // an external display sampled while focus sits elsewhere sees none of
+        // its own icons even though it carries them the moment focus lands
+        // there (#66). `icons.isEmpty` used to stand for the first case only;
+        // checking `leftmost` instead covers both, because a globally empty
+        // scan leaves it `nil` too. Either way, the cautious strip is what
+        // "could not measure" falls back to.
+        let crowded = leftmost.map { $0 < reach } ?? true
         return NotchGeometry(
             screen: screen,
             notchSize: CGSize(width: 180, height: max(menuBarHeight, NSStatusBar.system.thickness, 24)),


### PR DESCRIPTION
Разбор из #66 — второй из двух вариантов, которые ты сам там предложил, и который тебе больше нравится.

**Баг.** `crowded` считался по `icons.filter(bar.intersects)` — иконкам именно этого бара — но откатывался на «не тесно» (`false`), если ни одна не нашлась, а не на осторожную ветку, которую уже использует случай глобально пустого скана. С раздельными пространствами macOS рисует статус-иконки только на баре дисплея с фокусом: внешний монитор без фокуса в момент замера видит `leftmost == nil`, но `icons` при этом глобально не пуст — `crowded == false`, `guardsIcons == false`, и синтетическая чёлка занимает там всю высоту бара до первого закрытия последней панели (когда сработает `remeasure()`).

**Фикс.** Там же, где ты и предлагал — на месте, без более частого пересчёта. `icons.isEmpty` проверял только «глобально пустой скан»; заменил на `leftmost == nil`, которое покрывает и его (глобально пустой скан оставляет `leftmost` тем же `nil`), и локальный случай из #66.

```diff
-        let crowded = icons.isEmpty || (leftmost ?? .infinity) < reach
+        let crowded = leftmost.map { $0 < reach } ?? true
```

Проверить на двух дисплеях, как и ты, не могу — но привёл рассуждение к тому же выводу, что твоё, отдельным скриптом на голой логике `crowded()` (четыре случая: глобально пусто, локально пусто при глобально непустом, иконка близко, иконка далеко) — совпадает с ожиданием по всем четырём.

```
./Scripts/bundle.sh release   ✓
./Scripts/test-helper.sh      ✓
проверка ключей перевода      ✓
```
