### PR TITLE
Шаблон issue ведёт идеи в Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Идея или вопрос
+    url: https://github.com/akalikbergenov/cyclop/discussions
+    about: Обсудить до кода. Большая фича начинается здесь, а не с готового PR, см. CONTRIBUTING.md
   - name: Уязвимость
     url: https://github.com/akalikbergenov/cyclop/security/advisories/new
     about: Приватный канал, issue заводить не нужно


### PR DESCRIPTION
Discussions включены по решению PO. В выборе типа issue появилась ссылка «Идея или вопрос» на них: обсудить до кода, как просит CONTRIBUTING.