### PR TITLE
Релиз подписывается Developer ID и нотаризуется

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,65 @@ permissions:
 jobs:
   release:
     runs-on: macos-15
+    env:
+      # Секреты нельзя читать в `if` напрямую, поэтому их наличие снимается
+      # здесь в обычную переменную. Без сертификата workflow собирает ad-hoc,
+      # как локальная сборка: так пробный прогон работает и в форке без
+      # секретов, а релиз без подписи не выпустится — шаг ниже это проверит.
+      HAS_CERT: ${{ secrets.DEVELOPER_ID_P12 != '' }}
+      HAS_NOTARY: ${{ secrets.NOTARY_KEY_P8 != '' }}
     steps:
       - uses: actions/checkout@v5
         with:
           # Вся история и теги: список изменений считается от предыдущего тега.
           fetch-depth: 0
+
+      - name: Релиз без подписи не выпускается
+        if: github.ref_type == 'tag' && (env.HAS_CERT != 'true' || env.HAS_NOTARY != 'true')
+        run: |
+          echo "нет секретов подписи или нотаризации — см. docs/signing.md"
+          exit 1
+
+      - name: Сертификат Developer ID во временную связку ключей
+        if: env.HAS_CERT == 'true'
+        env:
+          P12_BASE64: ${{ secrets.DEVELOPER_ID_P12 }}
+          P12_PASSWORD: ${{ secrets.DEVELOPER_ID_P12_PASSWORD }}
+        run: |
+          # Своя связка на прогон, а не login: раннер одноразовый, но привычка
+          # правильная — ключ живёт ровно столько, сколько идёт сборка.
+          KEYCHAIN="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          printf '%s' "$P12_BASE64" | base64 --decode > "$RUNNER_TEMP/developer-id.p12"
+          security import "$RUNNER_TEMP/developer-id.p12" -k "$KEYCHAIN" -P "$P12_PASSWORD" \
+              -T /usr/bin/codesign -T /usr/bin/security
+          rm -f "$RUNNER_TEMP/developer-id.p12"
+          # Иначе codesign остановится на диалоге «разрешить доступ к ключу»,
+          # которого на раннере никто не увидит.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" \
+              | sed -n 's/.*"\(Developer ID Application: [^"]*\)".*/\1/p' | head -1)"
+          test -n "$IDENTITY" || { echo "в .p12 нет сертификата Developer ID Application"; exit 1; }
+          echo "CODESIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+          echo "    подпись: $IDENTITY"
+
+      - name: Ключ нотаризации
+        if: env.HAS_NOTARY == 'true'
+        env:
+          KEY_BASE64: ${{ secrets.NOTARY_KEY_P8 }}
+        run: |
+          printf '%s' "$KEY_BASE64" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+          chmod 600 "$RUNNER_TEMP/AuthKey.p8"
+          {
+            echo "NOTARY_KEY_PATH=$RUNNER_TEMP/AuthKey.p8"
+            echo "NOTARY_KEY_ID=${{ secrets.NOTARY_KEY_ID }}"
+            echo "NOTARY_ISSUER_ID=${{ secrets.NOTARY_ISSUER_ID }}"
+            echo "NOTARIZE=1"
+          } >> "$GITHUB_ENV"
 
       - name: Тег, версия и заметки согласованы
         run: |
@@ -34,6 +88,8 @@ jobs:
           fi
 
       - name: Образ
+        # С CODESIGN_IDENTITY и NOTARIZE=1 из шагов выше — подписанный и
+        # нотаризованный; без них — ad-hoc, для пробного прогона.
         run: ./Scripts/dmg.sh
 
       - name: Контрольная сумма

--- a/Resources/Cyclop.entitlements
+++ b/Resources/Cyclop.entitlements
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Два права, и оба не дают приложению ничего сверх того, что оно уже
+         делает: под hardened runtime без них система молча запрещает то, что
+         без hardened runtime разрешала. Само разрешение остаётся за
+         пользователем — TCC спросит его в тот же момент, что и раньше.
+
+         Apple-события держат запасной путь управления плеером (AppleScript для
+         Music и Spotify). Написано @DontTrustMexD в #1. -->
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+    <!-- Календарь читается через EventKit на вкладке «Календарь», по кнопке.
+         Без этого ключа hardened runtime отказывает в доступе до того, как
+         TCC успевает спросить. -->
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
+</dict>
+</plist>

--- a/Scripts/bundle.sh
+++ b/Scripts/bundle.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Builds Cyclop.app without Xcode: SwiftPM produces the binary, this script
-# assembles the bundle around it and ad-hoc signs it.
+# assembles the bundle around it and signs it — ad-hoc by default, with a
+# Developer ID when CODESIGN_IDENTITY names one.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -72,7 +73,18 @@ clang -dynamiclib -fobjc-arc -O2 \
     -o "$APP/Contents/Resources/libcyclopmedia.dylib" \
     "$ROOT/Sources/CyclopMediaHelper/helper.m"
 
-echo "==> ad-hoc signing"
+# Подпись. Кем — решает CODESIGN_IDENTITY: пусто или «-» — ad-hoc, как для
+# любой локальной сборки; «Developer ID Application: …» — настоящая, с
+# hardened runtime и отметкой времени, как для релиза. Ключ и сертификат
+# в скрипте не живут, они в связке ключей того, кто выпускает, или в
+# секретах раннера (см. docs/signing.md).
+IDENTITY="${CODESIGN_IDENTITY:--}"
+if [ "$IDENTITY" = "-" ]; then
+    echo "==> ad-hoc signing"
+else
+    echo "==> signing as $IDENTITY"
+fi
+
 # Расширенные атрибуты снимаются первыми. iCloud вешает на файлы
 # com.apple.FinderInfo, а codesign отказывается подписывать что-либо с ним —
 # «resource fork, Finder information, or similar detritus not allowed». Папка
@@ -80,16 +92,35 @@ echo "==> ad-hoc signing"
 # репозитория там перестает подписываться, стоило его туда перенести.
 xattr -cr "$APP"
 
+# Сначала вложенное, потом бандл, и без --deep: Apple объявила его устаревшим,
+# он подписывает вложенное теми же условиями, что и бандл, и молча пропускает
+# часть случаев. Подпись бандла запечатывает Resources целиком, dylib в том
+# числе: подменённый хелпер с настоящей подписью не пройдёт Gatekeeper, и
+# отдельная сверка хеша из #1 становится не нужна.
+#
+# Hardened runtime — только с настоящей подписью. Связка «ad-hoc + runtime +
+# чужой perl» ломала Now Playing без единого сообщения (#20), а даёт она
+# ad-hoc-сборке ничего: нотаризовать её всё равно нельзя.
+#
 # Ошибка не глушится и не понижается до предупреждения. Раньше отказ печатал
 # мягкую строку и возвращал ноль: скрипт доходил до «done», а в build лежал
 # бандл, про который codesign говорит «code object is not signed at all».
 # Заметить это можно было только по возвращающимся запросам TCC — то есть у
 # того, кто уже поставил приложение.
-codesign --force --deep --sign - "$APP" || {
+if [ "$IDENTITY" = "-" ]; then
+    codesign --force --sign - "$APP/Contents/Resources/libcyclopmedia.dylib"
+    codesign --force --sign - "$APP"
+else
+    codesign --force --timestamp --sign "$IDENTITY" \
+        "$APP/Contents/Resources/libcyclopmedia.dylib"
+    codesign --force --timestamp --options runtime \
+        --entitlements "$ROOT/Resources/Cyclop.entitlements" \
+        --sign "$IDENTITY" "$APP"
+fi || {
     echo "!!! codesign не смог подписать бандл — см. вывод выше" >&2
     exit 1
 }
-codesign --verify --strict "$APP" || {
+codesign --verify --strict --deep "$APP" || {
     echo "!!! подпись не прошла проверку" >&2
     exit 1
 }

--- a/Scripts/dmg.sh
+++ b/Scripts/dmg.sh
@@ -14,6 +14,22 @@ DMG="$ROOT/build/Cyclop-$VERSION.dmg"
 # заметить это можно лишь запустив его.
 "$ROOT/Scripts/bundle.sh" release
 
+# Настоящая подпись (CODESIGN_IDENTITY) и NOTARIZE=1 — релизный путь: сначала
+# нотаризуется и скрепляется приложение, потом подписывается, нотаризуется и
+# скрепляется образ. Два раунда, а не один, потому что билет скрепляется к
+# тому, что подавали: скрепка на образе не доходит до приложения внутри, а
+# именно оно запускается офлайн у того, кто скачал образ вчера.
+IDENTITY="${CODESIGN_IDENTITY:--}"
+SIGNED=false
+[ "$IDENTITY" != "-" ] && SIGNED=true
+if [ "$SIGNED" = true ] && [ "${NOTARIZE:-0}" = 1 ]; then
+    ZIP="$ROOT/build/Cyclop-$VERSION.zip"
+    rm -f "$ZIP"
+    ditto -c -k --keepParent "$APP" "$ZIP"
+    "$ROOT/Scripts/notarize.sh" "$ZIP" "$APP"
+    rm -f "$ZIP"
+fi
+
 echo "==> раскладка образа"
 STAGE="$(mktemp -d)"
 trap 'rm -rf "$STAGE"' EXIT
@@ -30,6 +46,14 @@ hdiutil create \
     -quiet \
     "$DMG"
 
+if [ "$SIGNED" = true ]; then
+    echo "==> подпись образа"
+    codesign --force --timestamp --sign "$IDENTITY" "$DMG"
+    if [ "${NOTARIZE:-0}" = 1 ]; then
+        "$ROOT/Scripts/notarize.sh" "$DMG"
+    fi
+fi
+
 SIZE="$(du -h "$DMG" | cut -f1 | tr -d ' ')"
 echo "==> готово: $DMG ($SIZE)"
 
@@ -43,8 +67,15 @@ fi
 echo "==> версия внутри совпадает: $INSIDE"
 
 # Сказано здесь, потому что узнать это иначе можно только от человека, у
-# которого приложение не открылось.
-if ! spctl -a "$APP" >/dev/null 2>&1; then
+# которого приложение не открылось. Для релизной сборки это не предупреждение,
+# а провал: подписанный и нотаризованный образ обязан проходить Gatekeeper.
+if [ "$SIGNED" = true ]; then
+    spctl -a -vv "$APP" || { echo "!!! Gatekeeper не принимает приложение" >&2; exit 1; }
+    if [ "${NOTARIZE:-0}" = 1 ]; then
+        spctl -a -t open --context context:primary-signature -vv "$DMG" \
+            || { echo "!!! Gatekeeper не принимает образ" >&2; exit 1; }
+    fi
+elif ! spctl -a "$APP" >/dev/null 2>&1; then
     cat <<'NOTE'
 
     Внимание: сборка подписана ad-hoc, без Developer ID, и не нотаризована.

--- a/Scripts/notarize.sh
+++ b/Scripts/notarize.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Нотаризация одного файла — .zip с приложением или .dmg — и скрепка билета
+# к тому, что внутри. Без билета Gatekeeper проверяет подпись у Apple по сети
+# при первом запуске; со скрепкой — офлайн.
+#
+# Учётные данные — App Store Connect API key, двумя способами:
+#   NOTARY_PROFILE      имя профиля из `xcrun notarytool store-credentials`
+#                       (локально: ключ лежит в связке ключей, а не в окружении);
+#   NOTARY_KEY_ID, NOTARY_ISSUER_ID, NOTARY_KEY_PATH
+#                       сам ключ .p8 и его идентификаторы (на раннере, из секретов).
+#
+#   Scripts/notarize.sh build/Cyclop.zip build/Cyclop.app
+#   Scripts/notarize.sh build/Cyclop-1.0.dmg
+set -euo pipefail
+
+FILE="${1:?что нотаризовать}"
+STAPLE="${2:-$FILE}"
+
+fail() { echo "!!! $1" >&2; exit 1; }
+
+if [ -n "${NOTARY_PROFILE:-}" ]; then
+    AUTH=(--keychain-profile "$NOTARY_PROFILE")
+elif [ -n "${NOTARY_KEY_ID:-}" ] && [ -n "${NOTARY_ISSUER_ID:-}" ] && [ -n "${NOTARY_KEY_PATH:-}" ]; then
+    AUTH=(--key "$NOTARY_KEY_PATH" --key-id "$NOTARY_KEY_ID" --issuer "$NOTARY_ISSUER_ID")
+else
+    fail "нет учётных данных нотаризации: NOTARY_PROFILE или NOTARY_KEY_ID + NOTARY_ISSUER_ID + NOTARY_KEY_PATH"
+fi
+
+echo "==> нотаризация $(basename "$FILE")"
+# --wait: обычно минута-две. Лог запрашивается всегда, а не только при
+# отказе: предупреждения Apple приходят и в принятом ответе, и увидеть их
+# можно только так.
+OUT="$(xcrun notarytool submit "$FILE" "${AUTH[@]}" --wait --output-format json)"
+ID="$(printf '%s' "$OUT" | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+STATUS="$(printf '%s' "$OUT" | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])')"
+xcrun notarytool log "$ID" "${AUTH[@]}" 2>/dev/null | /usr/bin/python3 -c '
+import json,sys
+log=json.load(sys.stdin)
+for issue in log.get("issues") or []:
+    print(f"    {issue.get(\"severity\")}: {issue.get(\"path\")}: {issue.get(\"message\")}")
+' || true
+[ "$STATUS" = "Accepted" ] || fail "нотаризация: $STATUS (id $ID)"
+
+echo "==> скрепка билета к $(basename "$STAPLE")"
+xcrun stapler staple -q "$STAPLE"
+xcrun stapler validate -q "$STAPLE"

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -1,0 +1,98 @@
+# Подпись и нотаризация
+
+Релиз подписывается сертификатом Developer ID и нотаризуется у Apple. Тогда
+приложение открывается с первого раза, без «Открыть всё равно», а подменённый
+файл внутри бандла не запускается вовсе (#20). Делает это раннер в
+`release.yml`; ему нужны пять секретов. Как их получить — ниже, один раз.
+
+Локальная сборка (`Scripts/bundle.sh`) остаётся ad-hoc и ничего из этого не
+требует.
+
+## 1. Сертификат Developer ID Application
+
+Xcode не нужен, хватает Command Line Tools и Связки ключей.
+
+1. **Запрос сертификата.** Связка ключей → меню Связка ключей → Ассистент
+   сертификации → Запросить сертификат у бюро сертификации. Почта аккаунта
+   разработчика, имя любое, «Сохранён на диск». Закрытый ключ при этом ложится
+   в связку ключей login — он и есть половина сертификата, экспортировать
+   потом придётся именно из этой связки.
+2. **Выпуск.** [developer.apple.com/account/resources/certificates](https://developer.apple.com/account/resources/certificates/list)
+   → «+» → **Developer ID Application** (не Installer, не Mac App
+   Distribution) → загрузить запрос → скачать `.cer` → двойной клик, чтобы он
+   лёг в login.
+3. **Проверка.**
+   ```sh
+   security find-identity -v -p codesigning
+   ```
+   Должна быть строка `"Developer ID Application: Имя (TEAMID)"`. Если
+   сертификат виден, но помечен как невалидный, не хватает промежуточного
+   сертификата Apple: скачать **Developer ID - G2** с
+   [apple.com/certificateauthority](https://www.apple.com/certificateauthority/)
+   и тоже открыть двойным кликом.
+
+## 2. Экспорт для раннера
+
+Связка ключей → Мои сертификаты → правой кнопкой по «Developer ID
+Application: …» → Экспортировать → формат `.p12`, придумать пароль. Файл
+содержит и сертификат, и закрытый ключ: после загрузки в секреты удалить.
+
+```sh
+base64 -i DeveloperID.p12 | gh secret set DEVELOPER_ID_P12
+gh secret set DEVELOPER_ID_P12_PASSWORD      # спросит пароль от .p12
+```
+
+## 3. Ключ нотаризации
+
+[appstoreconnect.apple.com](https://appstoreconnect.apple.com) → Пользователи
+и доступ → Интеграции → App Store Connect API → Team Keys → «+». Имя любое,
+роль **Developer** — большего нотаризации не нужно. Записать **Key ID** и
+**Issuer ID** (сверху страницы), скачать `.p8` — Apple отдаёт его **один
+раз**, второй раз не скачать.
+
+```sh
+gh secret set NOTARY_KEY_ID                  # Key ID
+gh secret set NOTARY_ISSUER_ID               # Issuer ID
+base64 -i AuthKey_XXXXXXXXXX.p8 | gh secret set NOTARY_KEY_P8
+```
+
+## 4. Проверить локально до первого релиза
+
+Один раз положить ключ в связку ключей под именем профиля, чтобы не держать
+его в окружении:
+
+```sh
+xcrun notarytool store-credentials cyclop \
+    --key AuthKey_XXXXXXXXXX.p8 --key-id XXXXXXXXXX --issuer 00000000-0000-0000-0000-000000000000
+```
+
+Потом собрать релизный образ так же, как это сделает раннер:
+
+```sh
+CODESIGN_IDENTITY="Developer ID Application: Имя (TEAMID)" \
+NOTARIZE=1 NOTARY_PROFILE=cyclop \
+./Scripts/dmg.sh
+```
+
+Скрипт нотаризует приложение, потом образ, скрепляет билеты к обоим и в
+конце сам спрашивает Gatekeeper. Если он дошёл до «готово», образ откроется
+на любом Mac с первого раза. Проверить всё равно стоит на машине, где Cyclop
+ещё не запускали: разница между «у меня работает» и «у него открылось» — и
+есть суть проверки (#20).
+
+## Что где лежит
+
+| Секрет | Что это |
+|---|---|
+| `DEVELOPER_ID_P12` | сертификат с ключом, base64 |
+| `DEVELOPER_ID_P12_PASSWORD` | пароль от него |
+| `NOTARY_KEY_ID` | Key ID ключа App Store Connect |
+| `NOTARY_ISSUER_ID` | Issuer ID команды |
+| `NOTARY_KEY_P8` | сам ключ `.p8`, base64 |
+
+Без первых двух раннер собирает ad-hoc и релиз по тегу не выпускает; пробный
+прогон (ручной запуск `release.yml`) работает и без них.
+
+Сертификат Developer ID действует пять лет, ключ App Store Connect не
+истекает, пока его не отозвать. Оба можно отозвать на тех же страницах, где
+выпускали, — это единственное, что надо сделать, если секреты утекли.


### PR DESCRIPTION
Developer Program оплачен, активация до двух суток. Этот PR готовит всё, что не требует самого сертификата; проверить подписанный путь можно будет, когда он появится в связке ключей.

**Что внутри**
- `Scripts/bundle.sh`: подпись по `CODESIGN_IDENTITY`, по умолчанию ad-hoc как раньше. С Developer ID: hardened runtime, timestamp, entitlements. Вложенный dylib первым, бандл вторым, без `--deep`. Сверка хеша хелпера из #1 не переносится: подпись бандла запечатывает Resources, и это делает то же самое честнее.
- `Resources/Cyclop.entitlements`: Apple-события (из #1, @DontTrustMexD) и календарь, оба нужны под hardened runtime.
- `Scripts/notarize.sh` и `Scripts/dmg.sh` с `NOTARIZE=1`: нотаризация приложения и образа, скрепка билетов к обоим, проверка Gatekeeper в конце.
- `release.yml`: пять секретов → временная связка ключей; без секретов ad-hoc для пробного прогона, релиз по тегу без подписи падает явно.
- `docs/signing.md`: пошагово, как получить сертификат без Xcode, экспортировать его, завести ключ нотаризации и положить секреты.

**Проверено:** ad-hoc путь локально (`dmg.sh`, подписи dylib и бандла, `test-helper.sh`), синтаксис скриптов и yaml. Подписанный путь проверяется после активации аккаунта, локально по разделу 4 из docs/signing.md, и первым релизом.

Закрывает #20 после первого подписанного релиза, не раньше.