### PR TITLE
notarize.sh: вывод предупреждений Apple работает на системном Python

### DIFF
--- a/Scripts/notarize.sh
+++ b/Scripts/notarize.sh
@@ -34,10 +34,10 @@ OUT="$(xcrun notarytool submit "$FILE" "${AUTH[@]}" --wait --output-format json)
 ID="$(printf '%s' "$OUT" | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
 STATUS="$(printf '%s' "$OUT" | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])')"
 xcrun notarytool log "$ID" "${AUTH[@]}" 2>/dev/null | /usr/bin/python3 -c '
-import json,sys
-log=json.load(sys.stdin)
+import json, sys
+log = json.load(sys.stdin)
 for issue in log.get("issues") or []:
-    print(f"    {issue.get(\"severity\")}: {issue.get(\"path\")}: {issue.get(\"message\")}")
+    print("    {}: {}: {}".format(issue.get("severity"), issue.get("path"), issue.get("message")))
 ' || true
 [ "$STATUS" = "Accepted" ] || fail "нотаризация: $STATUS (id $ID)"
 


### PR DESCRIPTION
Найдено на первом реальном прогоне нотаризации: f-строка с `\"` внутри выражения не парсится Python 3.9 (`/usr/bin/python3` на macOS 15). Сама нотаризация проходила, терялись только предупреждения из лога. Заменено на `format`. Проверено на логе реальной submission.