### PR TITLE
Кнопка перед доступом к календарю больше не говорит «Разрешить»

### DIFF
--- a/Resources/en.lproj/Localizable.strings
+++ b/Resources/en.lproj/Localizable.strings
@@ -81,7 +81,7 @@
 "No other meetings this week" = "No other meetings this week";
 "See your next meetings" = "See your next meetings";
 "Cyclop needs access to Calendar. It is the only permission\nthe app asks for, and only for this tab." = "Cyclop needs access to Calendar. It is the only permission\nthe app asks for, and only for this tab.";
-"Allow" = "Allow";
+"Continue" = "Continue";
 "Calendar access is off" = "Calendar access is off";
 "Settings → Privacy → Calendars" = "Settings → Privacy → Calendars";
 "No more meetings" = "No more meetings";

--- a/Resources/ru.lproj/Localizable.strings
+++ b/Resources/ru.lproj/Localizable.strings
@@ -80,7 +80,7 @@
 "No other meetings this week" = "Других встреч на неделе нет";
 "See your next meetings" = "Показать ближайшие встречи";
 "Cyclop needs access to Calendar. It is the only permission\nthe app asks for, and only for this tab." = "Нужен доступ к Календарю. Это единственное разрешение,\nкоторое просит Cyclop — и только для этой вкладки.";
-"Allow" = "Разрешить";
+"Continue" = "Продолжить";
 "Calendar access is off" = "Доступ к Календарю закрыт";
 "Settings → Privacy → Calendars" = "Настройки → Конфиденциальность → Календари";
 "No more meetings" = "Встреч больше нет";

--- a/Sources/Cyclop/UI/CalendarPane.swift
+++ b/Sources/Cyclop/UI/CalendarPane.swift
@@ -288,10 +288,13 @@ struct CalendarPane: View {
             // Padding and background belong inside the label: with .plain the
             // hit area is the label itself, so decorating the Button from the
             // outside leaves a capsule that only responds on its lettering.
+            // "Continue", not "Allow": the granting happens in the system
+            // dialog that follows, and App Review reads our own button saying
+            // "Allow" as the app pressing for a yes before macOS has asked.
             Button {
                 calendar.requestAccess()
             } label: {
-                Text("Allow")
+                Text("Continue")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.white)
                     .padding(.horizontal, 14)


### PR DESCRIPTION
## Что случилось

App Review завернул сборку по **guideline 5.1.1(iv)**:

> The app encourages or directs users to allow the app to access the calendar. A custom message appears before the permission request, and to proceed users press a "Allow" button. Use words like "Continue" or "Next" on the button instead.

Логика правила простая: разрешение даёт **системный** диалог, и слово «разрешить» принадлежит ему. Собственная кнопка приложения с тем же словом читается как попытка добиться согласия до того, как система вообще спросила.

## Что изменилось

`Text("Allow")` → `Text("Continue")` в экране-предисловии `CalendarPane`, плюс ключ в обоих файлах локализации:

```
en: "Continue" = "Continue";
ru: "Continue" = "Продолжить";
```

Ключ `"Allow"` удалён — больше нигде не используется.

Сам экран не тронут: он по-прежнему объясняет, зачем нужен доступ, и остаётся единственным местом, где приложение о чём-то просит.

## Проверки

```
./Scripts/bundle.sh release   ✓
./Scripts/test-helper.sh      ✓
```

Правка вошла в сборку 5, загруженную в App Store Connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMfvpKHFNpx3boYXtw6g